### PR TITLE
Изменение логики работы флага IsConnected в QuikTerminal

### DIFF
--- a/Connectors/Quik/QuikTerminal.cs
+++ b/Connectors/Quik/QuikTerminal.cs
@@ -533,7 +533,7 @@ namespace StockSharp.Quik
 		/// </summary>
 		public bool IsConnected
 		{
-			get { return !StatusBar.GetText().IsEmpty(); }
+			get { return MainWindow.GetMenu().Items[0].Items[1].IsEnabled; }
 		}
 
 		private QuikSessionHolder _sessionHolder;


### PR DESCRIPTION
Предыдущий вариант предполагал, что существует зависимость наличия или отсутствия текста в статусбаре с состоянием подключения квика к серверу. Такая связь может наблюдаться если с квиком никто не работает, что на практике встречается редко. Логичнее связать состояние соединения с состоянием кнопки подключения или отключения квика от сервера.