### PR TITLE
Fix DateTimeOffset in GetArchiveFinInfoFromDB

### DIFF
--- a/Connectors/AlfaDirect/Native/AlfaWrapper.cs
+++ b/Connectors/AlfaDirect/Native/AlfaWrapper.cs
@@ -336,7 +336,7 @@ namespace StockSharp.AlfaDirect.Native
 			var timeFrame = (AlfaTimeFrames)(TimeSpan)message.Arg;
 			//to = timeFrame.GetCandleBounds(series.Security).Min;
 
-			var data = _ad.GetArchiveFinInfoFromDB(placeCode, message.SecurityId.SecurityCode, timeFrame.Interval, message.From.Convert(TimeHelper.Moscow), message.To.Convert(TimeHelper.Moscow));
+			var data = _ad.GetArchiveFinInfoFromDB(placeCode, message.SecurityId.SecurityCode, timeFrame.Interval, message.From.Convert(TimeHelper.Moscow).DateTime, message.To.Convert(TimeHelper.Moscow).DateTime);
 
 			if (_ad.LastResult != StateCodes.stcSuccess)
 				ThrowInError((tagStateCodes)_ad.LastResult);

--- a/Samples/AlfaDirect/SampleAlfaCandles/MainWindow.xaml
+++ b/Samples/AlfaDirect/SampleAlfaCandles/MainWindow.xaml
@@ -4,7 +4,7 @@
 		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
 		xmlns:loc="clr-namespace:StockSharp.Localization;assembly=StockSharp.Localization"
 		xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
-		Title="{x:Static loc:LocalizedStrings.XamlStr568}" Height="250" Width="350"
+		Title="{x:Static loc:LocalizedStrings.XamlStr568}" Height="260" Width="350"
 		WindowStartupLocation="CenterScreen" ResizeMode="NoResize">
 
     <Grid Margin="10">
@@ -20,7 +20,7 @@
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
-			<RowDefinition Height="15" />
+			<RowDefinition Height="30" />
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 
@@ -43,7 +43,9 @@
 
 		<Label Content="{x:Static loc:LocalizedStrings.XamlStr254}" Grid.Column="0" Grid.Row="6" VerticalAlignment="Center" HorizontalAlignment="Right"/>
 		<xctk:DateTimePicker x:Name="To" Grid.Column="1" Grid.Row="6" Margin="5"/>
-		
+
+		<CheckBox x:Name="RealTime" Content="RealTime candles" Grid.Column="1" HorizontalAlignment="Left" Grid.Row="7" VerticalAlignment="Center" Width="120" Margin="5,5,0,5" Checked="RealTime_Checked" Unchecked="RealTime_Checked"/>
+
 		<Button x:Name="ShowChart" Grid.Column="1" Width="100" Grid.Row="8" Content="{x:Static loc:LocalizedStrings.Str3200}" IsEnabled="False" Click="ShowChartClick" />
 	</Grid>
 </Window>

--- a/Samples/AlfaDirect/SampleAlfaCandles/MainWindow.xaml.cs
+++ b/Samples/AlfaDirect/SampleAlfaCandles/MainWindow.xaml.cs
@@ -101,7 +101,7 @@ namespace SampleAlfaCandles
 			var timeFrame = (TimeSpan)HistoryInterval.SelectedItem;
 
 			var from = From.Value.Value;
-			var to = To.Value.Value;
+			var to = RealTime.IsChecked.Value ? DateTimeOffset.MaxValue : To.Value.Value;
 
 			if (from > to)
 			{
@@ -136,6 +136,11 @@ namespace SampleAlfaCandles
 		private void SecuritySelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 			ShowChart.IsEnabled = SelectedSecurity != null;
+		}
+
+		private void RealTime_Checked(object sender, RoutedEventArgs e)
+		{
+			To.IsEnabled = !(sender as CheckBox).IsChecked.Value;
 		}
 	}
 }


### PR DESCRIPTION
Во время выполнения GetArchiveFinInfoFromDB отваливается с ошибкой, так как понимает только DateTime вместо DateTimeOffset:
2015/05/12 14:00:00.626|Error  |AlfaTrader|System.ArgumentException: Значение не попадает в ожидаемый диапазон.
   в System.StubHelpers.ObjectMarshaler.ConvertToNative(Object objSrc, IntPtr pDstVariant)
   в ADLite.AlfaDirectClass.GetArchiveFinInfoFromDB(String PlaceCode, String PCode, Int32 Period, Object DateFrom, Object DateTo)
   в StockSharp.AlfaDirect.Native.AlfaWrapper.LookupCandles(MarketDataMessage message)
   в StockSharp.AlfaDirect.AlfaDirectMessageAdapter.ProcessMarketDataMessage(MarketDataMessage message)
   в StockSharp.AlfaDirect.AlfaDirectMessageAdapter.OnSendInMessage(Message message)
   в StockSharp.Messages.MessageAdapter.SendInMessage(Message message)