### PR TITLE
Quik ApiWrapper connection check

### DIFF
--- a/Connectors/Quik/Native/ApiWrapper.cs
+++ b/Connectors/Quik/Native/ApiWrapper.cs
@@ -70,6 +70,12 @@ namespace StockSharp.Quik.Native
 
 		public void Connect(string path)
 		{
+			if (IsConnected)
+			{
+				ConnectionChanged.SafeInvoke(Codes.QuikConnected, null, null);
+				return;
+			}
+
 			if (IsDllConnected() == Codes.DllConnected)
 				return;
 


### PR DESCRIPTION
Иногда возникает ситуация, когда нам нужно подключиться, а подключение уже установлено. В этом случае ConnectionState зависает на Connecting, и отключиться уже не получается. Для таких случаев вводим проверку, и устанавливаем правильное состояние подключения.