### PR TITLE
PnLManager fix

### DIFF
--- a/Algo/PnL/PnLQueue.cs
+++ b/Algo/PnL/PnLQueue.cs
@@ -212,7 +212,7 @@ namespace StockSharp.Algo.PnL
 				RealizedPnL += _multiplier * pnl;
 			}
 
-			return new PnLInfo(trade, closedVolume, pnl);
+			return new PnLInfo(trade, closedVolume, _multiplier * pnl);
 		}
 
 		/// <summary>

--- a/Algo/PnL/PnLQueue.cs
+++ b/Algo/PnL/PnLQueue.cs
@@ -39,8 +39,6 @@ namespace StockSharp.Algo.PnL
 		public PnLQueue(SecurityId securityId)
 		{
 			SecurityId = securityId;
-			PriceStep = 1;
-			StepPrice = 1;
 		}
 
 		/// <summary>
@@ -78,9 +76,25 @@ namespace StockSharp.Algo.PnL
 			}
 		}
 
+		private decimal _lotMultiplier;
+
+		/// <summary>
+		/// Lot size multiplier
+		/// </summary>
+		public decimal LotMultiplier
+		{
+			get { return _lotMultiplier; }
+			private set
+			{
+				_lotMultiplier = value;
+				UpdateMultiplier();
+			}
+		}
+
 		/// <summary>
 		/// Multiplier.
 		/// </summary>
+		/// <remarks>Returns a value by which to multiply the PnL in points, to return a PnL in money </remarks>
 		public decimal Multiplier
 		{
 			get { return _multiplier; }
@@ -241,6 +255,13 @@ namespace StockSharp.Algo.PnL
 				AskPrice = (decimal)askPrice;
 				_recalcUnrealizedPnL = true;
 			}
+
+			var lotMultiplier = levelMsg.Changes.TryGetValue(Level1Fields.Multiplier);
+			if (lotMultiplier != null)
+			{
+				LotMultiplier = (decimal)lotMultiplier;
+				_recalcUnrealizedPnL = true;
+			}
 		}
 
 		/// <summary>
@@ -271,9 +292,9 @@ namespace StockSharp.Algo.PnL
 
 		private void UpdateMultiplier()
 		{
-			_multiplier = StepPrice == 0 || PriceStep == 0 
-				? 1 
-				: StepPrice / PriceStep;
+			_multiplier = StepPrice == 0 || PriceStep == 0 || LotMultiplier == 0
+				? 0 
+				: StepPrice / PriceStep * LotMultiplier;
 		}
 
 		private static decimal GetPnL(decimal price, decimal volume, Sides side, decimal marketPrice)

--- a/Algo/Strategies/Strategy.cs
+++ b/Algo/Strategies/Strategy.cs
@@ -2176,7 +2176,8 @@ namespace StockSharp.Algo.Strategies
 		{
 			var msg = new Level1ChangeMessage { SecurityId = security.ToSecurityId(), ServerTime = CurrentTime }
 					.TryAdd(Level1Fields.PriceStep, security.PriceStep)
-					.TryAdd(Level1Fields.StepPrice, this.GetSecurityValue<decimal?>(security, Level1Fields.StepPrice));
+					.TryAdd(Level1Fields.StepPrice, security.StepPrice)
+					.TryAdd(Level1Fields.Multiplier, security.Multiplier);
 
 			PnLManager.ProcessMessage(msg);
 		}


### PR DESCRIPTION
Немного причесал PnLManager, в сторону работоспособности "из коробки".
1. Lot Multiplier added to PnL Multiplier calculation. 
Убрана инициализация PriceStep и StepPrice из конструктора и если не возможно рассчитать _multiplier, то он равен нулю 0. Логика в том, что лучше пусть будет PnL равен нулю, и  ты будешь смотреть что стряслось, чем будешь видить не корректные значения.
Так же в расчет Multiplier добавлен размер лота.
2. RealizedPnL fix. Был баг в том, что реализованная прибыль по сделке возвращалась в пунктах, без домножения на _multiplier.
Теперь и реализованная и нереализованная прибыль в деньгах