### PR TITLE
Очистка контейнера при обнулении любого Complex индикатора.

### DIFF
--- a/Algo/Indicators/BaseComplexIndicator.cs
+++ b/Algo/Indicators/BaseComplexIndicator.cs
@@ -118,6 +118,7 @@ namespace StockSharp.Algo.Indicators
 		/// </summary>
 		public override void Reset()
 		{
+            base.Reset();
 			InnerIndicators.ForEach(i => i.Reset());
 		}
 


### PR DESCRIPTION
Во всех других базовых классах это работает (например в BaseIndicator.cs и LengthIndicator.cs)