### PR TITLE
Issue #223 fix

### DIFF
--- a/Algo/Strategies/Strategy.cs
+++ b/Algo/Strategies/Strategy.cs
@@ -1350,6 +1350,9 @@ namespace StockSharp.Algo.Strategies
 					if (!WaitAllTrades)
 						return true;
 
+					if (order.IsCanceled())
+						return true;
+
 					//var leftVolume = order.Volume - order.GetMatchedVolume(Connector, true);
 
 					//if (leftVolume == 0)
@@ -2278,6 +2281,17 @@ namespace StockSharp.Algo.Strategies
 			foreach (var trade in filteredTrades)
 			{
 				ProcessRisk(trade.ToMessage());
+			}
+
+			if (ProcessState == ProcessStates.Stopping)
+			{
+				foreach (var rule in Rules.SyncGet(c => c.ToArray()))
+				{
+					if (this.TryRemoveWithExclusive(rule))
+						_childStrategies.TryRemoveStoppedRule(rule);
+				}
+
+				TryFinalStop();
 			}
 		}
 


### PR DESCRIPTION
Как и написано [здесь](https://github.com/StockSharp/StockSharp/issues/223) стратегия зависает в состоянии Stopping.
Происходит это потому, что не выполняются условия для удаления пакета правил, применяемых для ордера в методе _ApplyMonitorRules_ класса _Strategy_
Возможно есть более элегантное решение по удалению этих правил.
