### PR TITLE
Fix Telegram channel search when service missing

### DIFF
--- a/Alerts.Interfaces/AlertsExtensions.cs
+++ b/Alerts.Interfaces/AlertsExtensions.cs
@@ -13,5 +13,7 @@ public static class AlertsExtensions
 	/// <param name="channelId">Channel id.</param>
 	/// <returns>Channel.</returns>
 	public static ITelegramChannel TryFindChannel(this long channelId)
-		=> ConfigManager.TryGetService<IEnumerable<ITelegramChannel>>().FirstOrDefault(c => c.Id == channelId);
+		=> ConfigManager
+		.TryGetService<IEnumerable<ITelegramChannel>>()?
+		.FirstOrDefault(c => c.Id == channelId);
 }


### PR DESCRIPTION
## Summary
- avoid null reference in `TryFindChannel`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bd66f3b48323b43c754f3959cb60