### PR TITLE
Fix comment description in annotation interface

### DIFF
--- a/Charting.Interfaces/IAnnotationData.cs
+++ b/Charting.Interfaces/IAnnotationData.cs
@@ -45,7 +45,7 @@ public interface IAnnotationData
 	/// <summary>Brush to fill background.</summary>
 	Brush Fill { get; set; }
 
-	/// <summary>Brush to fill background.</summary>
+	/// <summary>Text color.</summary>
 	Brush Foreground { get; set; }
 
 	/// <summary>Line thickness.</summary>


### PR DESCRIPTION
## Summary
- fix mislabeled comment for `Foreground` in `IAnnotationData`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bd6c286883238ee3b582b62901a5