### PR TITLE
Use GetInnerDecimal across complex indicator values

### DIFF
--- a/Algo/Indicators/AdaptivePriceZone.cs
+++ b/Algo/Indicators/AdaptivePriceZone.cs
@@ -187,15 +187,15 @@ public class AdaptivePriceZoneValue : ComplexIndicatorValue<AdaptivePriceZone>
 	/// <summary>
 	/// Gets the moving average value.
 	/// </summary>
-	public decimal MovingAverage => InnerValues[TypedIndicator.Ma].ToDecimal();
+	public decimal MovingAverage => GetInnerDecimal(TypedIndicator.Ma);
 
 	/// <summary>
 	/// Gets the upper band value.
 	/// </summary>
-	public decimal UpperBand => InnerValues[TypedIndicator.UpperBand].ToDecimal();
+	public decimal UpperBand => GetInnerDecimal(TypedIndicator.UpperBand);
 
 	/// <summary>
 	/// Gets the lower band value.
 	/// </summary>
-	public decimal LowerBand => InnerValues[TypedIndicator.LowerBand].ToDecimal();
+	public decimal LowerBand => GetInnerDecimal(TypedIndicator.LowerBand);
 }

--- a/Algo/Indicators/Alligator.cs
+++ b/Algo/Indicators/Alligator.cs
@@ -100,15 +100,15 @@ public class AlligatorValue : ComplexIndicatorValue<Alligator>
 	/// <summary>
 	/// Gets the <see cref="Alligator.Jaw"/> value.
 	/// </summary>
-	public decimal Jaw => InnerValues[TypedIndicator.Jaw].ToDecimal();
+	public decimal Jaw => GetInnerDecimal(TypedIndicator.Jaw);
 
 	/// <summary>
 	/// Gets the <see cref="Alligator.Teeth"/> value.
 	/// </summary>
-	public decimal Teeth => InnerValues[TypedIndicator.Teeth].ToDecimal();
+	public decimal Teeth => GetInnerDecimal(TypedIndicator.Teeth);
 
 	/// <summary>
 	/// Gets the <see cref="Alligator.Lips"/> value.
 	/// </summary>
-	public decimal Lips => InnerValues[TypedIndicator.Lips].ToDecimal();
+	public decimal Lips => GetInnerDecimal(TypedIndicator.Lips);
 }

--- a/Algo/Indicators/AverageDirectionalIndex.cs
+++ b/Algo/Indicators/AverageDirectionalIndex.cs
@@ -113,5 +113,5 @@ public class AverageDirectionalIndexValue : ComplexIndicatorValue<AverageDirecti
 	/// <summary>
 	/// Gets the <see cref="AverageDirectionalIndex.MovingAverage"/> value.
 	/// </summary>
-	public decimal MovingAverage => InnerValues[TypedIndicator.MovingAverage].ToDecimal();
+	public decimal MovingAverage => GetInnerDecimal(TypedIndicator.MovingAverage);
 }

--- a/Algo/Indicators/BollingerBands.cs
+++ b/Algo/Indicators/BollingerBands.cs
@@ -149,15 +149,15 @@ public class BollingerBandsValue : ComplexIndicatorValue<BollingerBands>
 	/// <summary>
 	/// Gets the <see cref="BollingerBands.MovingAverage"/> value.
 	/// </summary>
-	public decimal MovingAverage => InnerValues[TypedIndicator.MovingAverage].ToDecimal();
+	public decimal MovingAverage => GetInnerDecimal(TypedIndicator.MovingAverage);
 
 	/// <summary>
 	/// Gets the <see cref="BollingerBands.UpBand"/> value.
 	/// </summary>
-	public decimal UpBand => InnerValues[TypedIndicator.UpBand].ToDecimal();
+	public decimal UpBand => GetInnerDecimal(TypedIndicator.UpBand);
 
 	/// <summary>
 	/// Gets the <see cref="BollingerBands.LowBand"/> value.
 	/// </summary>
-	public decimal LowBand => InnerValues[TypedIndicator.LowBand].ToDecimal();
+	public decimal LowBand => GetInnerDecimal(TypedIndicator.LowBand);
 }

--- a/Algo/Indicators/ChandeKrollStop.cs
+++ b/Algo/Indicators/ChandeKrollStop.cs
@@ -186,10 +186,10 @@ public class ChandeKrollStopValue : ComplexIndicatorValue<ChandeKrollStop>
 	/// <summary>
 	/// Gets the highest stop line.
 	/// </summary>
-	public decimal Highest => InnerValues[TypedIndicator.Highest].ToDecimal();
+	public decimal Highest => GetInnerDecimal(TypedIndicator.Highest);
 
 	/// <summary>
 	/// Gets the lowest stop line.
 	/// </summary>
-	public decimal Lowest => InnerValues[TypedIndicator.Lowest].ToDecimal();
+	public decimal Lowest => GetInnerDecimal(TypedIndicator.Lowest);
 }

--- a/Algo/Indicators/CompositeMomentum.cs
+++ b/Algo/Indicators/CompositeMomentum.cs
@@ -162,10 +162,10 @@ public class CompositeMomentumValue : ComplexIndicatorValue<CompositeMomentum>
 	/// <summary>
 	/// Gets the SMA value.
 	/// </summary>
-	public decimal Sma => InnerValues[TypedIndicator.Sma].ToDecimal();
+	public decimal Sma => GetInnerDecimal(TypedIndicator.Sma);
 
 	/// <summary>
 	/// Gets the composite momentum line.
 	/// </summary>
-	public decimal CompositeLine => InnerValues[TypedIndicator.CompositeLine].ToDecimal();
+	public decimal CompositeLine => GetInnerDecimal(TypedIndicator.CompositeLine);
 }

--- a/Algo/Indicators/ConnorsRSI.cs
+++ b/Algo/Indicators/ConnorsRSI.cs
@@ -247,20 +247,20 @@ public class ConnorsRSIValue : ComplexIndicatorValue<ConnorsRSI>
 	/// <summary>
 	/// Gets the RSI component.
 	/// </summary>
-	public decimal Rsi => InnerValues[TypedIndicator.Rsi].ToDecimal();
+	public decimal Rsi => GetInnerDecimal(TypedIndicator.Rsi);
 
 	/// <summary>
 	/// Gets the UpDown RSI component.
 	/// </summary>
-	public decimal UpDownRsi => InnerValues[TypedIndicator.UpDownRsi].ToDecimal();
+	public decimal UpDownRsi => GetInnerDecimal(TypedIndicator.UpDownRsi);
 
 	/// <summary>
 	/// Gets the ROC RSI component.
 	/// </summary>
-	public decimal RocRsi => InnerValues[TypedIndicator.RocRsi].ToDecimal();
+	public decimal RocRsi => GetInnerDecimal(TypedIndicator.RocRsi);
 
 	/// <summary>
 	/// Gets the composite RSI line.
 	/// </summary>
-	public decimal CrsiLine => InnerValues[TypedIndicator.CrsiLine].ToDecimal();
+	public decimal CrsiLine => GetInnerDecimal(TypedIndicator.CrsiLine);
 }

--- a/Algo/Indicators/ConstanceBrownCompositeIndex.cs
+++ b/Algo/Indicators/ConstanceBrownCompositeIndex.cs
@@ -167,15 +167,15 @@ public class ConstanceBrownCompositeIndexValue : ComplexIndicatorValue<Constance
 	/// <summary>
 	/// Gets the RSI component.
 	/// </summary>
-	public decimal Rsi => InnerValues[TypedIndicator.Rsi].ToDecimal();
+	public decimal Rsi => GetInnerDecimal(TypedIndicator.Rsi);
 
 	/// <summary>
 	/// Gets the stochastic component.
 	/// </summary>
-	public decimal Stoch => InnerValues[TypedIndicator.Stoch].ToDecimal();
+	public decimal Stoch => GetInnerDecimal(TypedIndicator.Stoch);
 
 	/// <summary>
 	/// Gets the composite index line.
 	/// </summary>
-	public decimal CompositeIndexLine => InnerValues[TypedIndicator.CompositeIndexLine].ToDecimal();
+	public decimal CompositeIndexLine => GetInnerDecimal(TypedIndicator.CompositeIndexLine);
 }

--- a/Algo/Indicators/DirectionalIndex.cs
+++ b/Algo/Indicators/DirectionalIndex.cs
@@ -124,10 +124,10 @@ public class DirectionalIndexValue : ComplexIndicatorValue<DirectionalIndex>
 	/// <summary>
 	/// Gets the <see cref="DirectionalIndex.Plus"/> value.
 	/// </summary>
-	public decimal Plus => InnerValues[TypedIndicator.Plus].ToDecimal();
+	public decimal Plus => GetInnerDecimal(TypedIndicator.Plus);
 	
 	/// <summary>
 	/// Gets the <see cref="DirectionalIndex.Minus"/> value.
 	/// </summary>
-	public decimal Minus => InnerValues[TypedIndicator.Minus].ToDecimal();
+	public decimal Minus => GetInnerDecimal(TypedIndicator.Minus);
 }

--- a/Algo/Indicators/DonchianChannels.cs
+++ b/Algo/Indicators/DonchianChannels.cs
@@ -141,15 +141,15 @@ public class DonchianChannelsValue : ComplexIndicatorValue<DonchianChannels>
 	/// <summary>
 	/// Gets the <see cref="DonchianChannels.UpperBand"/> value.
 	/// </summary>
-	public decimal UpperBand => InnerValues[TypedIndicator.UpperBand].ToDecimal();
+	public decimal UpperBand => GetInnerDecimal(TypedIndicator.UpperBand);
 
 	/// <summary>
 	/// Gets the <see cref="DonchianChannels.LowerBand"/> value.
 	/// </summary>
-	public decimal LowerBand => InnerValues[TypedIndicator.LowerBand].ToDecimal();
+	public decimal LowerBand => GetInnerDecimal(TypedIndicator.LowerBand);
 
 	/// <summary>
 	/// Gets the <see cref="DonchianChannels.Middle"/> value.
 	/// </summary>
-	public decimal Middle => InnerValues[TypedIndicator.Middle].ToDecimal();
+	public decimal Middle => GetInnerDecimal(TypedIndicator.Middle);
 }

--- a/Algo/Indicators/EhlersFisherTransform.cs
+++ b/Algo/Indicators/EhlersFisherTransform.cs
@@ -181,10 +181,10 @@ public class EhlersFisherTransformValue : ComplexIndicatorValue<EhlersFisherTran
 	/// <summary>
 	/// Gets the main line value.
 	/// </summary>
-	public decimal MainLine => InnerValues[TypedIndicator.MainLine].ToDecimal();
+	public decimal MainLine => GetInnerDecimal(TypedIndicator.MainLine);
 
 	/// <summary>
 	/// Gets the trigger line value.
 	/// </summary>
-	public decimal TriggerLine => InnerValues[TypedIndicator.TriggerLine].ToDecimal();
+	public decimal TriggerLine => GetInnerDecimal(TypedIndicator.TriggerLine);
 }

--- a/Algo/Indicators/Envelope.cs
+++ b/Algo/Indicators/Envelope.cs
@@ -149,15 +149,15 @@ public class EnvelopeValue : ComplexIndicatorValue<Envelope>
 	/// <summary>
 	/// Gets the <see cref="Envelope.Middle"/> value.
 	/// </summary>
-	public decimal Middle => InnerValues[TypedIndicator.Middle].ToDecimal();
+	public decimal Middle => GetInnerDecimal(TypedIndicator.Middle);
 
 	/// <summary>
 	/// Gets the <see cref="Envelope.Upper"/> value.
 	/// </summary>
-	public decimal Upper => InnerValues[TypedIndicator.Upper].ToDecimal();
+	public decimal Upper => GetInnerDecimal(TypedIndicator.Upper);
 
 	/// <summary>
 	/// Gets the <see cref="Envelope.Lower"/> value.
 	/// </summary>
-	public decimal Lower => InnerValues[TypedIndicator.Lower].ToDecimal();
+	public decimal Lower => GetInnerDecimal(TypedIndicator.Lower);
 }

--- a/Algo/Indicators/FibonacciRetracement.cs
+++ b/Algo/Indicators/FibonacciRetracement.cs
@@ -161,5 +161,5 @@ public class FibonacciRetracementValue : ComplexIndicatorValue<FibonacciRetracem
 	/// <summary>
 	/// Gets all level values.
 	/// </summary>
-	public decimal[] Levels => TypedIndicator.Levels.Select(l => InnerValues[l].ToDecimal()).ToArray();
+	public decimal[] Levels => TypedIndicator.Levels.Select(l => GetInnerDecimal(l)).ToArray();
 }

--- a/Algo/Indicators/Fractals.cs
+++ b/Algo/Indicators/Fractals.cs
@@ -33,12 +33,12 @@ public class FractalsValue : ComplexIndicatorValue<Fractals>
 	/// <summary>
 	/// Gets the <see cref="Fractals.Up"/> value.
 	/// </summary>
-	public decimal Up => InnerValues[TypedIndicator.Up].ToDecimal();
+	public decimal Up => GetInnerDecimal(TypedIndicator.Up);
 
 	/// <summary>
 	/// Gets the <see cref="Fractals.Down"/> value.
 	/// </summary>
-	public decimal Down => InnerValues[TypedIndicator.Down].ToDecimal();
+	public decimal Down => GetInnerDecimal(TypedIndicator.Down);
 
 	/// <summary>
 	/// Cast object from <see cref="FractalsValue"/> to <see cref="bool"/>.

--- a/Algo/Indicators/GatorOscillator.cs
+++ b/Algo/Indicators/GatorOscillator.cs
@@ -90,10 +90,10 @@ public class GatorOscillatorValue : ComplexIndicatorValue<GatorOscillator>
 	/// <summary>
 	/// Gets the <see cref="GatorOscillator.Histogram1"/> value.
 	/// </summary>
-	public decimal Histogram1 => InnerValues[TypedIndicator.Histogram1].ToDecimal();
+	public decimal Histogram1 => GetInnerDecimal(TypedIndicator.Histogram1);
 
 	/// <summary>
 	/// Gets the <see cref="GatorOscillator.Histogram2"/> value.
 	/// </summary>
-	public decimal Histogram2 => InnerValues[TypedIndicator.Histogram2].ToDecimal();
+	public decimal Histogram2 => GetInnerDecimal(TypedIndicator.Histogram2);
 }

--- a/Algo/Indicators/GuppyMultipleMovingAverage.cs
+++ b/Algo/Indicators/GuppyMultipleMovingAverage.cs
@@ -45,5 +45,5 @@ public class GuppyMultipleMovingAverageValue : ComplexIndicatorValue<GuppyMultip
 	/// <summary>
 	/// Gets values of all moving averages.
 	/// </summary>
-	public decimal[] Averages => [.. TypedIndicator.InnerIndicators.Select(i => InnerValues[i].ToDecimal())];
+	public decimal[] Averages => [.. TypedIndicator.InnerIndicators.Select(i => GetInnerDecimal(i))];
 }

--- a/Algo/Indicators/Ichimoku.cs
+++ b/Algo/Indicators/Ichimoku.cs
@@ -117,25 +117,25 @@ public class IchimokuValue : ComplexIndicatorValue<Ichimoku>
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.Tenkan"/> value.
 	/// </summary>
-	public decimal Tenkan => InnerValues[TypedIndicator.Tenkan].ToDecimal();
+	public decimal Tenkan => GetInnerDecimal(TypedIndicator.Tenkan);
 
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.Kijun"/> value.
 	/// </summary>
-	public decimal Kijun => InnerValues[TypedIndicator.Kijun].ToDecimal();
+	public decimal Kijun => GetInnerDecimal(TypedIndicator.Kijun);
 
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.SenkouA"/> value.
 	/// </summary>
-	public decimal SenkouA => InnerValues[TypedIndicator.SenkouA].ToDecimal();
+	public decimal SenkouA => GetInnerDecimal(TypedIndicator.SenkouA);
 
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.SenkouB"/> value.
 	/// </summary>
-	public decimal SenkouB => InnerValues[TypedIndicator.SenkouB].ToDecimal();
+	public decimal SenkouB => GetInnerDecimal(TypedIndicator.SenkouB);
 
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.Chinkou"/> value.
 	/// </summary>
-	public decimal Chinkou => InnerValues[TypedIndicator.Chinkou].ToDecimal();
+	public decimal Chinkou => GetInnerDecimal(TypedIndicator.Chinkou);
 }

--- a/Algo/Indicators/KasePeakOscillator.cs
+++ b/Algo/Indicators/KasePeakOscillator.cs
@@ -198,10 +198,10 @@ public class KasePeakOscillatorValue : ComplexIndicatorValue<KasePeakOscillator>
 	/// <summary>
 	/// Gets the <see cref="KasePeakOscillator.ShortTerm"/> value.
 	/// </summary>
-	public decimal ShortTerm => InnerValues[TypedIndicator.ShortTerm].ToDecimal();
+	public decimal ShortTerm => GetInnerDecimal(TypedIndicator.ShortTerm);
 
 	/// <summary>
 	/// Gets the <see cref="KasePeakOscillator.LongTerm"/> value.
 	/// </summary>
-	public decimal LongTerm => InnerValues[TypedIndicator.LongTerm].ToDecimal();
+	public decimal LongTerm => GetInnerDecimal(TypedIndicator.LongTerm);
 }

--- a/Algo/Indicators/KeltnerChannels.cs
+++ b/Algo/Indicators/KeltnerChannels.cs
@@ -193,15 +193,15 @@ public class KeltnerChannelsValue : ComplexIndicatorValue<KeltnerChannels>
 	/// <summary>
 	/// Gets the <see cref="KeltnerChannels.Middle"/> value.
 	/// </summary>
-	public decimal Middle => InnerValues[TypedIndicator.Middle].ToDecimal();
+	public decimal Middle => GetInnerDecimal(TypedIndicator.Middle);
 
 	/// <summary>
 	/// Gets the <see cref="KeltnerChannels.Upper"/> value.
 	/// </summary>
-	public decimal Upper => InnerValues[TypedIndicator.Upper].ToDecimal();
+	public decimal Upper => GetInnerDecimal(TypedIndicator.Upper);
 
 	/// <summary>
 	/// Gets the <see cref="KeltnerChannels.Lower"/> value.
 	/// </summary>
-	public decimal Lower => InnerValues[TypedIndicator.Lower].ToDecimal();
+	public decimal Lower => GetInnerDecimal(TypedIndicator.Lower);
 }

--- a/Algo/Indicators/KlingerVolumeOscillator.cs
+++ b/Algo/Indicators/KlingerVolumeOscillator.cs
@@ -140,15 +140,15 @@ public class KlingerVolumeOscillatorValue : ComplexIndicatorValue<KlingerVolumeO
 	/// <summary>
 	/// Gets the short EMA value.
 	/// </summary>
-	public decimal ShortEma => InnerValues[TypedIndicator.ShortEma].ToDecimal();
+	public decimal ShortEma => GetInnerDecimal(TypedIndicator.ShortEma);
 
 	/// <summary>
 	/// Gets the long EMA value.
 	/// </summary>
-	public decimal LongEma => InnerValues[TypedIndicator.LongEma].ToDecimal();
+	public decimal LongEma => GetInnerDecimal(TypedIndicator.LongEma);
 
 	/// <summary>
 	/// Gets the oscillator value.
 	/// </summary>
-	public decimal Oscillator => InnerValues[TypedIndicator].ToDecimal();
+	public decimal Oscillator => GetInnerDecimal(TypedIndicator);
 }

--- a/Algo/Indicators/KnowSureThing.cs
+++ b/Algo/Indicators/KnowSureThing.cs
@@ -134,10 +134,10 @@ public class KnowSureThingValue : ComplexIndicatorValue<KnowSureThing>
 	/// <summary>
 	/// Gets the KST line value.
 	/// </summary>
-	public decimal KstLine => InnerValues[TypedIndicator.KstLine].ToDecimal();
+	public decimal KstLine => GetInnerDecimal(TypedIndicator.KstLine);
 
 	/// <summary>
 	/// Gets the signal line value.
 	/// </summary>
-	public decimal Signal => InnerValues[TypedIndicator.Signal].ToDecimal();
+	public decimal Signal => GetInnerDecimal(TypedIndicator.Signal);
 }

--- a/Algo/Indicators/LinearRegression.cs
+++ b/Algo/Indicators/LinearRegression.cs
@@ -139,20 +139,20 @@ public class LinearRegressionValue : ComplexIndicatorValue<LinearRegression>
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.LinearReg"/> value.
 	/// </summary>
-	public decimal LinearReg => InnerValues[TypedIndicator.LinearReg].ToDecimal();
+	public decimal LinearReg => GetInnerDecimal(TypedIndicator.LinearReg);
 
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.RSquared"/> value.
 	/// </summary>
-	public decimal RSquared => InnerValues[TypedIndicator.RSquared].ToDecimal();
+	public decimal RSquared => GetInnerDecimal(TypedIndicator.RSquared);
 
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.LinearRegSlope"/> value.
 	/// </summary>
-	public decimal LinearRegSlope => InnerValues[TypedIndicator.LinearRegSlope].ToDecimal();
+	public decimal LinearRegSlope => GetInnerDecimal(TypedIndicator.LinearRegSlope);
 
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.StandardError"/> value.
 	/// </summary>
-	public decimal StandardError => InnerValues[TypedIndicator.StandardError].ToDecimal();
+	public decimal StandardError => GetInnerDecimal(TypedIndicator.StandardError);
 }

--- a/Algo/Indicators/MovingAverageConvergenceDivergenceHistogram.cs
+++ b/Algo/Indicators/MovingAverageConvergenceDivergenceHistogram.cs
@@ -98,10 +98,10 @@ public class MovingAverageConvergenceDivergenceHistogramValue : ComplexIndicator
 	/// <summary>
 	/// Gets the MACD value.
 	/// </summary>
-	public decimal Macd => InnerValues[TypedIndicator.Macd].ToDecimal();
+	public decimal Macd => GetInnerDecimal(TypedIndicator.Macd);
 
 	/// <summary>
 	/// Gets the signal line value.
 	/// </summary>
-	public decimal Signal => InnerValues[TypedIndicator.SignalMa].ToDecimal();
+	public decimal Signal => GetInnerDecimal(TypedIndicator.SignalMa);
 }

--- a/Algo/Indicators/MovingAverageConvergenceDivergenceSignal.cs
+++ b/Algo/Indicators/MovingAverageConvergenceDivergenceSignal.cs
@@ -86,10 +86,10 @@ public class MovingAverageConvergenceDivergenceSignalValue : ComplexIndicatorVal
 	/// <summary>
 	/// Gets the MACD value.
 	/// </summary>
-	public decimal Macd => InnerValues[TypedIndicator.Macd].ToDecimal();
+	public decimal Macd => GetInnerDecimal(TypedIndicator.Macd);
 
 	/// <summary>
 	/// Gets the signal line value.
 	/// </summary>
-	public decimal Signal => InnerValues[TypedIndicator.SignalMa].ToDecimal();
+	public decimal Signal => GetInnerDecimal(TypedIndicator.SignalMa);
 }

--- a/Algo/Indicators/MovingAverageRibbon.cs
+++ b/Algo/Indicators/MovingAverageRibbon.cs
@@ -154,5 +154,5 @@ public class MovingAverageRibbonValue : ComplexIndicatorValue<MovingAverageRibbo
 	/// <summary>
 	/// Gets all moving average values.
 	/// </summary>
-	public decimal[] Averages => TypedIndicator.InnerIndicators.Select(i => InnerValues[i].ToDecimal()).ToArray();
+	public decimal[] Averages => TypedIndicator.InnerIndicators.Select(i => GetInnerDecimal(i)).ToArray();
 }

--- a/Algo/Indicators/PercentagePriceOscillator.cs
+++ b/Algo/Indicators/PercentagePriceOscillator.cs
@@ -145,10 +145,10 @@ public class PercentagePriceOscillatorValue : ComplexIndicatorValue<PercentagePr
 	/// <summary>
 	/// Gets the short EMA value.
 	/// </summary>
-	public decimal ShortEma => InnerValues[TypedIndicator.ShortEma].ToDecimal();
+	public decimal ShortEma => GetInnerDecimal(TypedIndicator.ShortEma);
 
 	/// <summary>
 	/// Gets the long EMA value.
 	/// </summary>
-	public decimal LongEma => InnerValues[TypedIndicator.LongEma].ToDecimal();
+	public decimal LongEma => GetInnerDecimal(TypedIndicator.LongEma);
 }

--- a/Algo/Indicators/PercentageVolumeOscillator.cs
+++ b/Algo/Indicators/PercentageVolumeOscillator.cs
@@ -150,10 +150,10 @@ public class PercentageVolumeOscillatorValue : ComplexIndicatorValue<PercentageV
 	/// <summary>
 	/// Gets the short EMA value.
 	/// </summary>
-	public decimal ShortEma => InnerValues[TypedIndicator.ShortEma].ToDecimal();
+	public decimal ShortEma => GetInnerDecimal(TypedIndicator.ShortEma);
 
 	/// <summary>
 	/// Gets the long EMA value.
 	/// </summary>
-	public decimal LongEma => InnerValues[TypedIndicator.LongEma].ToDecimal();
+	public decimal LongEma => GetInnerDecimal(TypedIndicator.LongEma);
 }

--- a/Algo/Indicators/PivotPoints.cs
+++ b/Algo/Indicators/PivotPoints.cs
@@ -114,25 +114,25 @@ public class PivotPointsValue : ComplexIndicatorValue<PivotPoints>
 	/// <summary>
 	/// Gets the Pivot Point value.
 	/// </summary>
-	public decimal PivotPoint => InnerValues[TypedIndicator.PivotPoint].ToDecimal();
+	public decimal PivotPoint => GetInnerDecimal(TypedIndicator.PivotPoint);
 
 	/// <summary>
 	/// Gets the R1 value.
 	/// </summary>
-	public decimal R1 => InnerValues[TypedIndicator.R1].ToDecimal();
+	public decimal R1 => GetInnerDecimal(TypedIndicator.R1);
 
 	/// <summary>
 	/// Gets the R2 value.
 	/// </summary>
-	public decimal R2 => InnerValues[TypedIndicator.R2].ToDecimal();
+	public decimal R2 => GetInnerDecimal(TypedIndicator.R2);
 
 	/// <summary>
 	/// Gets the S1 value.
 	/// </summary>
-	public decimal S1 => InnerValues[TypedIndicator.S1].ToDecimal();
+	public decimal S1 => GetInnerDecimal(TypedIndicator.S1);
 
 	/// <summary>
 	/// Gets the S2 value.
 	/// </summary>
-	public decimal S2 => InnerValues[TypedIndicator.S2].ToDecimal();
+	public decimal S2 => GetInnerDecimal(TypedIndicator.S2);
 }

--- a/Algo/Indicators/RainbowCharts.cs
+++ b/Algo/Indicators/RainbowCharts.cs
@@ -93,5 +93,5 @@ public class RainbowChartsValue : ComplexIndicatorValue<RainbowCharts>
 	/// <summary>
 	/// Gets values of all moving averages.
 	/// </summary>
-	public decimal[] Averages => TypedIndicator.InnerIndicators.Select(i => InnerValues[i].ToDecimal()).ToArray();
+	public decimal[] Averages => TypedIndicator.InnerIndicators.Select(i => GetInnerDecimal(i)).ToArray();
 }

--- a/Algo/Indicators/RelativeVigorIndex.cs
+++ b/Algo/Indicators/RelativeVigorIndex.cs
@@ -87,10 +87,10 @@ public class RelativeVigorIndexValue : ComplexIndicatorValue<RelativeVigorIndex>
 	/// <summary>
 	/// Gets the <see cref="RelativeVigorIndex.Average"/> value.
 	/// </summary>
-	public decimal Average => InnerValues[TypedIndicator.Average].ToDecimal();
+	public decimal Average => GetInnerDecimal(TypedIndicator.Average);
 
 	/// <summary>
 	/// Gets the <see cref="RelativeVigorIndex.Signal"/> value.
 	/// </summary>
-	public decimal Signal => InnerValues[TypedIndicator.Signal].ToDecimal();
+	public decimal Signal => GetInnerDecimal(TypedIndicator.Signal);
 }

--- a/Algo/Indicators/SineWave.cs
+++ b/Algo/Indicators/SineWave.cs
@@ -146,10 +146,10 @@ public class SineWaveValue : ComplexIndicatorValue<SineWave>
 	/// <summary>
 	/// Gets the main line value.
 	/// </summary>
-	public decimal Main => InnerValues[TypedIndicator.Main].ToDecimal();
+	public decimal Main => GetInnerDecimal(TypedIndicator.Main);
 
 	/// <summary>
 	/// Gets the lead line value.
 	/// </summary>
-	public decimal Lead => InnerValues[TypedIndicator.Lead].ToDecimal();
+	public decimal Lead => GetInnerDecimal(TypedIndicator.Lead);
 }

--- a/Algo/Indicators/StochasticOscillator.cs
+++ b/Algo/Indicators/StochasticOscillator.cs
@@ -76,10 +76,10 @@ public class StochasticOscillatorValue : ComplexIndicatorValue<StochasticOscilla
 	/// <summary>
 	/// Gets the %K value.
 	/// </summary>
-	public decimal KValue => InnerValues[TypedIndicator.K].ToDecimal();
+	public decimal KValue => GetInnerDecimal(TypedIndicator.K);
 
 	/// <summary>
 	/// Gets the %D value.
 	/// </summary>
-	public decimal DValue => InnerValues[TypedIndicator.D].ToDecimal();
+	public decimal DValue => GetInnerDecimal(TypedIndicator.D);
 }

--- a/Algo/Indicators/VortexIndicator.cs
+++ b/Algo/Indicators/VortexIndicator.cs
@@ -210,10 +210,10 @@ public class VortexIndicatorValue : ComplexIndicatorValue<VortexIndicator>
 	/// <summary>
 	/// Gets the <see cref="VortexIndicator.PlusVi"/> value.
 	/// </summary>
-	public decimal PlusVi => InnerValues[TypedIndicator.PlusVi].ToDecimal();
+	public decimal PlusVi => GetInnerDecimal(TypedIndicator.PlusVi);
 
 	/// <summary>
 	/// Gets the <see cref="VortexIndicator.MinusVi"/> value.
 	/// </summary>
-	public decimal MinusVi => InnerValues[TypedIndicator.MinusVi].ToDecimal();
+	public decimal MinusVi => GetInnerDecimal(TypedIndicator.MinusVi);
 }

--- a/Algo/Indicators/WaveTrendOscillator.cs
+++ b/Algo/Indicators/WaveTrendOscillator.cs
@@ -222,10 +222,10 @@ public class WaveTrendOscillatorValue : ComplexIndicatorValue<WaveTrendOscillato
 	/// <summary>
 	/// Gets the first Wavetrend line value.
 	/// </summary>
-	public decimal Wt1 => InnerValues[TypedIndicator.Wt1].ToDecimal();
+	public decimal Wt1 => GetInnerDecimal(TypedIndicator.Wt1);
 
 	/// <summary>
 	/// Gets the second Wavetrend line value.
 	/// </summary>
-	public decimal Wt2 => InnerValues[TypedIndicator.Wt2].ToDecimal();
+	public decimal Wt2 => GetInnerDecimal(TypedIndicator.Wt2);
 }

--- a/Algo/Indicators/WoodiesCCI.cs
+++ b/Algo/Indicators/WoodiesCCI.cs
@@ -95,10 +95,10 @@ public class WoodiesCCIValue : ComplexIndicatorValue<WoodiesCCI>
 	/// <summary>
 	/// Gets the CCI value.
 	/// </summary>
-	public decimal Cci => InnerValues[TypedIndicator.Cci].ToDecimal();
+	public decimal Cci => GetInnerDecimal(TypedIndicator.Cci);
 
 	/// <summary>
 	/// Gets the SMA value.
 	/// </summary>
-	public decimal Sma => InnerValues[TypedIndicator.Sma].ToDecimal();
+	public decimal Sma => GetInnerDecimal(TypedIndicator.Sma);
 }


### PR DESCRIPTION
## Summary
- standardize access to nested indicator values
- replace `InnerValues[...]` usages with `GetInnerDecimal` helper

## Testing
- `dotnet build -c Release -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e5d2ba688323b65969f91f9373d0