### PR TITLE
Expose IIndicatorValue in complex indicator values

### DIFF
--- a/Algo/Indicators/AdaptivePriceZone.cs
+++ b/Algo/Indicators/AdaptivePriceZone.cs
@@ -182,15 +182,30 @@ public class AdaptivePriceZoneValue(AdaptivePriceZone indicator, DateTimeOffset 
 	/// <summary>
 	/// Gets the moving average value.
 	/// </summary>
-	public decimal? MovingAverage => GetInnerDecimal(TypedIndicator.MovingAverage);
+	public IIndicatorValue MovingAverageValue => this[TypedIndicator.MovingAverage];
 
 	/// <summary>
 	/// Gets the upper band value.
 	/// </summary>
-	public decimal? UpperBand => GetInnerDecimal(TypedIndicator.UpperBand);
+	public IIndicatorValue UpperBandValue => this[TypedIndicator.UpperBand];
 
 	/// <summary>
 	/// Gets the lower band value.
 	/// </summary>
-	public decimal? LowerBand => GetInnerDecimal(TypedIndicator.LowerBand);
+	public IIndicatorValue LowerBandValue => this[TypedIndicator.LowerBand];
+
+	/// <summary>
+	/// Gets the moving average value.
+	/// </summary>
+	public decimal? MovingAverage => MovingAverageValue.ToNullableDecimal();
+
+	/// <summary>
+	/// Gets the upper band value.
+	/// </summary>
+	public decimal? UpperBand => UpperBandValue.ToNullableDecimal();
+
+	/// <summary>
+	/// Gets the lower band value.
+	/// </summary>
+	public decimal? LowerBand => LowerBandValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/Alligator.cs
+++ b/Algo/Indicators/Alligator.cs
@@ -95,15 +95,30 @@ public class AlligatorValue(Alligator indicator, DateTimeOffset time) : ComplexI
 	/// <summary>
 	/// Gets the <see cref="Alligator.Jaw"/> value.
 	/// </summary>
-	public decimal? Jaw => GetInnerDecimal(TypedIndicator.Jaw);
+	public IIndicatorValue JawValue => this[TypedIndicator.Jaw];
+
+	/// <summary>
+	/// Gets the <see cref="Alligator.Jaw"/> value.
+	/// </summary>
+	public decimal? Jaw => JawValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Alligator.Teeth"/> value.
 	/// </summary>
-	public decimal? Teeth => GetInnerDecimal(TypedIndicator.Teeth);
+	public IIndicatorValue TeethValue => this[TypedIndicator.Teeth];
+
+	/// <summary>
+	/// Gets the <see cref="Alligator.Teeth"/> value.
+	/// </summary>
+	public decimal? Teeth => TeethValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Alligator.Lips"/> value.
 	/// </summary>
-	public decimal? Lips => GetInnerDecimal(TypedIndicator.Lips);
+	public IIndicatorValue LipsValue => this[TypedIndicator.Lips];
+
+	/// <summary>
+	/// Gets the <see cref="Alligator.Lips"/> value.
+	/// </summary>
+	public decimal? Lips => LipsValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/Aroon.cs
+++ b/Algo/Indicators/Aroon.cs
@@ -280,10 +280,20 @@ public class AroonValue(Aroon indicator, DateTimeOffset time) : ComplexIndicator
 	/// <summary>
 	/// Gets the <see cref="Aroon.Up"/> value.
 	/// </summary>
-	public decimal? Up => GetInnerDecimal(TypedIndicator.Up);
+	public IIndicatorValue UpValue => this[TypedIndicator.Up];
+
+	/// <summary>
+	/// Gets the <see cref="Aroon.Up"/> value.
+	/// </summary>
+	public decimal? Up => UpValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Aroon.Down"/> value.
 	/// </summary>
-	public decimal? Down => GetInnerDecimal(TypedIndicator.Down);
+	public IIndicatorValue DownValue => this[TypedIndicator.Down];
+
+	/// <summary>
+	/// Gets the <see cref="Aroon.Down"/> value.
+	/// </summary>
+	public decimal? Down => DownValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/AverageDirectionalIndex.cs
+++ b/Algo/Indicators/AverageDirectionalIndex.cs
@@ -103,10 +103,20 @@ public class AverageDirectionalIndexValue(AverageDirectionalIndex indicator, Dat
 	/// <summary>
 	/// Gets the <see cref="AverageDirectionalIndex.Dx"/> value.
 	/// </summary>
-	public DirectionalIndexValue Dx => (DirectionalIndexValue)InnerValues[TypedIndicator.Dx];
+	public IIndicatorValue DxValue => this[TypedIndicator.Dx];
+
+	/// <summary>
+	/// Gets the <see cref="AverageDirectionalIndex.Dx"/> value.
+	/// </summary>
+	public DirectionalIndexValue Dx => (DirectionalIndexValue)DxValue;
 	
 	/// <summary>
 	/// Gets the <see cref="AverageDirectionalIndex.MovingAverage"/> value.
 	/// </summary>
-	public decimal? MovingAverage => GetInnerDecimal(TypedIndicator.MovingAverage);
+	public IIndicatorValue MovingAverageValue => this[TypedIndicator.MovingAverage];
+
+	/// <summary>
+	/// Gets the <see cref="AverageDirectionalIndex.MovingAverage"/> value.
+	/// </summary>
+	public decimal? MovingAverage => MovingAverageValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/BollingerBands.cs
+++ b/Algo/Indicators/BollingerBands.cs
@@ -144,15 +144,30 @@ public class BollingerBandsValue(BollingerBands indicator, DateTimeOffset time) 
 	/// <summary>
 	/// Gets the <see cref="BollingerBands.MovingAverage"/> value.
 	/// </summary>
-	public decimal? MovingAverage => GetInnerDecimal(TypedIndicator.MovingAverage);
+	public IIndicatorValue MovingAverageValue => this[TypedIndicator.MovingAverage];
+
+	/// <summary>
+	/// Gets the <see cref="BollingerBands.MovingAverage"/> value.
+	/// </summary>
+	public decimal? MovingAverage => MovingAverageValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="BollingerBands.UpBand"/> value.
 	/// </summary>
-	public decimal? UpBand => GetInnerDecimal(TypedIndicator.UpBand);
+	public IIndicatorValue UpBandValue => this[TypedIndicator.UpBand];
+
+	/// <summary>
+	/// Gets the <see cref="BollingerBands.UpBand"/> value.
+	/// </summary>
+	public decimal? UpBand => UpBandValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="BollingerBands.LowBand"/> value.
 	/// </summary>
-	public decimal? LowBand => GetInnerDecimal(TypedIndicator.LowBand);
+	public IIndicatorValue LowBandValue => this[TypedIndicator.LowBand];
+
+	/// <summary>
+	/// Gets the <see cref="BollingerBands.LowBand"/> value.
+	/// </summary>
+	public decimal? LowBand => LowBandValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/ChandeKrollStop.cs
+++ b/Algo/Indicators/ChandeKrollStop.cs
@@ -181,10 +181,20 @@ public class ChandeKrollStopValue(ChandeKrollStop indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the highest stop line.
 	/// </summary>
-	public decimal? Highest => GetInnerDecimal(TypedIndicator.Highest);
+	public IIndicatorValue HighestValue => this[TypedIndicator.Highest];
+
+	/// <summary>
+	/// Gets the highest stop line.
+	/// </summary>
+	public decimal? Highest => HighestValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the lowest stop line.
 	/// </summary>
-	public decimal? Lowest => GetInnerDecimal(TypedIndicator.Lowest);
+	public IIndicatorValue LowestValue => this[TypedIndicator.Lowest];
+
+	/// <summary>
+	/// Gets the lowest stop line.
+	/// </summary>
+	public decimal? Lowest => LowestValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/CompositeMomentum.cs
+++ b/Algo/Indicators/CompositeMomentum.cs
@@ -157,10 +157,20 @@ public class CompositeMomentumValue(CompositeMomentum indicator, DateTimeOffset 
 	/// <summary>
 	/// Gets the SMA value.
 	/// </summary>
-	public decimal? Sma => GetInnerDecimal(TypedIndicator.Sma);
+	public IIndicatorValue SmaValue => this[TypedIndicator.Sma];
+
+	/// <summary>
+	/// Gets the SMA value.
+	/// </summary>
+	public decimal? Sma => SmaValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the composite momentum line.
 	/// </summary>
-	public decimal? CompositeLine => GetInnerDecimal(TypedIndicator.CompositeLine);
+	public IIndicatorValue CompositeLineValue => this[TypedIndicator.CompositeLine];
+
+	/// <summary>
+	/// Gets the composite momentum line.
+	/// </summary>
+	public decimal? CompositeLine => CompositeLineValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/ConnorsRSI.cs
+++ b/Algo/Indicators/ConnorsRSI.cs
@@ -242,20 +242,40 @@ public class ConnorsRSIValue(ConnorsRSI indicator, DateTimeOffset time) : Comple
 	/// <summary>
 	/// Gets the RSI component.
 	/// </summary>
-	public decimal? Rsi => GetInnerDecimal(TypedIndicator.Rsi);
+	public IIndicatorValue RsiValue => this[TypedIndicator.Rsi];
+
+	/// <summary>
+	/// Gets the RSI component.
+	/// </summary>
+	public decimal? Rsi => RsiValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the UpDown RSI component.
 	/// </summary>
-	public decimal? UpDownRsi => GetInnerDecimal(TypedIndicator.UpDownRsi);
+	public IIndicatorValue UpDownRsiValue => this[TypedIndicator.UpDownRsi];
+
+	/// <summary>
+	/// Gets the UpDown RSI component.
+	/// </summary>
+	public decimal? UpDownRsi => UpDownRsiValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the ROC RSI component.
 	/// </summary>
-	public decimal? RocRsi => GetInnerDecimal(TypedIndicator.RocRsi);
+	public IIndicatorValue RocRsiValue => this[TypedIndicator.RocRsi];
+
+	/// <summary>
+	/// Gets the ROC RSI component.
+	/// </summary>
+	public decimal? RocRsi => RocRsiValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the composite RSI line.
 	/// </summary>
-	public decimal? CrsiLine => GetInnerDecimal(TypedIndicator.CrsiLine);
+	public IIndicatorValue CrsiLineValue => this[TypedIndicator.CrsiLine];
+
+	/// <summary>
+	/// Gets the composite RSI line.
+	/// </summary>
+	public decimal? CrsiLine => CrsiLineValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/ConstanceBrownCompositeIndex.cs
+++ b/Algo/Indicators/ConstanceBrownCompositeIndex.cs
@@ -164,15 +164,30 @@ public class ConstanceBrownCompositeIndexValue(ConstanceBrownCompositeIndex indi
 	/// <summary>
 	/// Gets the RSI component.
 	/// </summary>
-	public decimal? Rsi => GetInnerDecimal(TypedIndicator.Rsi);
+	public IIndicatorValue RsiValue => this[TypedIndicator.Rsi];
+
+	/// <summary>
+	/// Gets the RSI component.
+	/// </summary>
+	public decimal? Rsi => RsiValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the stochastic component.
 	/// </summary>
-	public decimal? Stoch => GetInnerDecimal(TypedIndicator.Stoch);
+	public IIndicatorValue StochValue => this[TypedIndicator.Stoch];
+
+	/// <summary>
+	/// Gets the stochastic component.
+	/// </summary>
+	public decimal? Stoch => StochValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the composite index line.
 	/// </summary>
-	public decimal? CompositeIndexLine => GetInnerDecimal(TypedIndicator.CompositeIndexLine);
+	public IIndicatorValue CompositeIndexLineValue => this[TypedIndicator.CompositeIndexLine];
+
+	/// <summary>
+	/// Gets the composite index line.
+	/// </summary>
+	public decimal? CompositeIndexLine => CompositeIndexLineValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/DirectionalIndex.cs
+++ b/Algo/Indicators/DirectionalIndex.cs
@@ -119,10 +119,20 @@ public class DirectionalIndexValue(DirectionalIndex indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="DirectionalIndex.Plus"/> value.
 	/// </summary>
-	public decimal? Plus => GetInnerDecimal(TypedIndicator.Plus);
+	public IIndicatorValue PlusValue => this[TypedIndicator.Plus];
+
+	/// <summary>
+	/// Gets the <see cref="DirectionalIndex.Plus"/> value.
+	/// </summary>
+	public decimal? Plus => PlusValue.ToNullableDecimal();
 	
 	/// <summary>
 	/// Gets the <see cref="DirectionalIndex.Minus"/> value.
 	/// </summary>
-	public decimal? Minus => GetInnerDecimal(TypedIndicator.Minus);
+	public IIndicatorValue MinusValue => this[TypedIndicator.Minus];
+
+	/// <summary>
+	/// Gets the <see cref="DirectionalIndex.Minus"/> value.
+	/// </summary>
+	public decimal? Minus => MinusValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/DonchianChannels.cs
+++ b/Algo/Indicators/DonchianChannels.cs
@@ -136,15 +136,30 @@ public class DonchianChannelsValue(DonchianChannels indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="DonchianChannels.UpperBand"/> value.
 	/// </summary>
-	public decimal? UpperBand => GetInnerDecimal(TypedIndicator.UpperBand);
+	public IIndicatorValue UpperBandValue => this[TypedIndicator.UpperBand];
+
+	/// <summary>
+	/// Gets the <see cref="DonchianChannels.UpperBand"/> value.
+	/// </summary>
+	public decimal? UpperBand => UpperBandValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="DonchianChannels.LowerBand"/> value.
 	/// </summary>
-	public decimal? LowerBand => GetInnerDecimal(TypedIndicator.LowerBand);
+	public IIndicatorValue LowerBandValue => this[TypedIndicator.LowerBand];
+
+	/// <summary>
+	/// Gets the <see cref="DonchianChannels.LowerBand"/> value.
+	/// </summary>
+	public decimal? LowerBand => LowerBandValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="DonchianChannels.Middle"/> value.
 	/// </summary>
-	public decimal? Middle => GetInnerDecimal(TypedIndicator.Middle);
+	public IIndicatorValue MiddleValue => this[TypedIndicator.Middle];
+
+	/// <summary>
+	/// Gets the <see cref="DonchianChannels.Middle"/> value.
+	/// </summary>
+	public decimal? Middle => MiddleValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/EhlersFisherTransform.cs
+++ b/Algo/Indicators/EhlersFisherTransform.cs
@@ -176,10 +176,20 @@ public class EhlersFisherTransformValue(EhlersFisherTransform indicator, DateTim
 	/// <summary>
 	/// Gets the main line value.
 	/// </summary>
-	public decimal? MainLine => GetInnerDecimal(TypedIndicator.MainLine);
+	public IIndicatorValue MainLineValue => this[TypedIndicator.MainLine];
+
+	/// <summary>
+	/// Gets the main line value.
+	/// </summary>
+	public decimal? MainLine => MainLineValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the trigger line value.
 	/// </summary>
-	public decimal? TriggerLine => GetInnerDecimal(TypedIndicator.TriggerLine);
+	public IIndicatorValue TriggerLineValue => this[TypedIndicator.TriggerLine];
+
+	/// <summary>
+	/// Gets the trigger line value.
+	/// </summary>
+	public decimal? TriggerLine => TriggerLineValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/Envelope.cs
+++ b/Algo/Indicators/Envelope.cs
@@ -141,15 +141,30 @@ public class EnvelopeValue(Envelope indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Envelope.Middle"/> value.
 	/// </summary>
-	public decimal? Middle => GetInnerDecimal(TypedIndicator.Middle);
+	public IIndicatorValue MiddleValue => this[TypedIndicator.Middle];
+
+	/// <summary>
+	/// Gets the <see cref="Envelope.Middle"/> value.
+	/// </summary>
+	public decimal? Middle => MiddleValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Envelope.Upper"/> value.
 	/// </summary>
-	public decimal? Upper => GetInnerDecimal(TypedIndicator.Upper);
+	public IIndicatorValue UpperValue => this[TypedIndicator.Upper];
+
+	/// <summary>
+	/// Gets the <see cref="Envelope.Upper"/> value.
+	/// </summary>
+	public decimal? Upper => UpperValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Envelope.Lower"/> value.
 	/// </summary>
-	public decimal? Lower => GetInnerDecimal(TypedIndicator.Lower);
+	public IIndicatorValue LowerValue => this[TypedIndicator.Lower];
+
+	/// <summary>
+	/// Gets the <see cref="Envelope.Lower"/> value.
+	/// </summary>
+	public decimal? Lower => LowerValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/FibonacciRetracement.cs
+++ b/Algo/Indicators/FibonacciRetracement.cs
@@ -151,5 +151,10 @@ public class FibonacciRetracementValue(FibonacciRetracement indicator, DateTimeO
 	/// <summary>
 	/// Gets all level values.
 	/// </summary>
-	public decimal?[] Levels => [.. TypedIndicator.Levels.Select(GetInnerDecimal)];
+	public IIndicatorValue[] LevelsValues => [.. TypedIndicator.Levels.Select(ind => this[ind])];
+
+	/// <summary>
+	/// Gets all level values.
+	/// </summary>
+	public decimal?[] Levels => [.. LevelsValues.Select(v => v.ToNullableDecimal())];
 }

--- a/Algo/Indicators/Fractals.cs
+++ b/Algo/Indicators/Fractals.cs
@@ -28,12 +28,22 @@ public class FractalsValue(Fractals fractals, DateTimeOffset time) : ComplexIndi
 	/// <summary>
 	/// Gets the <see cref="Fractals.Up"/> value.
 	/// </summary>
-	public decimal? Up => GetInnerDecimal(TypedIndicator.Up);
+	public IIndicatorValue UpValue => this[TypedIndicator.Up];
+
+	/// <summary>
+	/// Gets the <see cref="Fractals.Up"/> value.
+	/// </summary>
+	public decimal? Up => UpValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Fractals.Down"/> value.
 	/// </summary>
-	public decimal? Down => GetInnerDecimal(TypedIndicator.Down);
+	public IIndicatorValue DownValue => this[TypedIndicator.Down];
+
+	/// <summary>
+	/// Gets the <see cref="Fractals.Down"/> value.
+	/// </summary>
+	public decimal? Down => DownValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Cast object from <see cref="FractalsValue"/> to <see cref="bool"/>.

--- a/Algo/Indicators/GatorOscillator.cs
+++ b/Algo/Indicators/GatorOscillator.cs
@@ -85,10 +85,20 @@ public class GatorOscillatorValue(GatorOscillator indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="GatorOscillator.Histogram1"/> value.
 	/// </summary>
-	public decimal? Histogram1 => GetInnerDecimal(TypedIndicator.Histogram1);
+	public IIndicatorValue Histogram1Value => this[TypedIndicator.Histogram1];
+
+	/// <summary>
+	/// Gets the <see cref="GatorOscillator.Histogram1"/> value.
+	/// </summary>
+	public decimal? Histogram1 => Histogram1Value.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="GatorOscillator.Histogram2"/> value.
 	/// </summary>
-	public decimal? Histogram2 => GetInnerDecimal(TypedIndicator.Histogram2);
+	public IIndicatorValue Histogram2Value => this[TypedIndicator.Histogram2];
+
+	/// <summary>
+	/// Gets the <see cref="GatorOscillator.Histogram2"/> value.
+	/// </summary>
+	public decimal? Histogram2 => Histogram2Value.ToNullableDecimal();
 }

--- a/Algo/Indicators/GuppyMultipleMovingAverage.cs
+++ b/Algo/Indicators/GuppyMultipleMovingAverage.cs
@@ -40,5 +40,10 @@ public class GuppyMultipleMovingAverageValue(GuppyMultipleMovingAverage indicato
 	/// <summary>
 	/// Gets values of all moving averages.
 	/// </summary>
-	public decimal?[] Averages => [.. TypedIndicator.InnerIndicators.Select(GetInnerDecimal)];
+	public IIndicatorValue[] AveragesValues => [.. TypedIndicator.InnerIndicators.Select(ind => this[ind])];
+
+	/// <summary>
+	/// Gets values of all moving averages.
+	/// </summary>
+	public decimal?[] Averages => [.. AveragesValues.Select(v => v.ToNullableDecimal())];
 }

--- a/Algo/Indicators/Ichimoku.cs
+++ b/Algo/Indicators/Ichimoku.cs
@@ -112,25 +112,50 @@ public class IchimokuValue(Ichimoku indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.Tenkan"/> value.
 	/// </summary>
-	public decimal? Tenkan => GetInnerDecimal(TypedIndicator.Tenkan);
+	public IIndicatorValue TenkanValue => this[TypedIndicator.Tenkan];
+
+	/// <summary>
+	/// Gets the <see cref="Ichimoku.Tenkan"/> value.
+	/// </summary>
+	public decimal? Tenkan => TenkanValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.Kijun"/> value.
 	/// </summary>
-	public decimal? Kijun => GetInnerDecimal(TypedIndicator.Kijun);
+	public IIndicatorValue KijunValue => this[TypedIndicator.Kijun];
+
+	/// <summary>
+	/// Gets the <see cref="Ichimoku.Kijun"/> value.
+	/// </summary>
+	public decimal? Kijun => KijunValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.SenkouA"/> value.
 	/// </summary>
-	public decimal? SenkouA => GetInnerDecimal(TypedIndicator.SenkouA);
+	public IIndicatorValue SenkouAValue => this[TypedIndicator.SenkouA];
+
+	/// <summary>
+	/// Gets the <see cref="Ichimoku.SenkouA"/> value.
+	/// </summary>
+	public decimal? SenkouA => SenkouAValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.SenkouB"/> value.
 	/// </summary>
-	public decimal? SenkouB => GetInnerDecimal(TypedIndicator.SenkouB);
+	public IIndicatorValue SenkouBValue => this[TypedIndicator.SenkouB];
+
+	/// <summary>
+	/// Gets the <see cref="Ichimoku.SenkouB"/> value.
+	/// </summary>
+	public decimal? SenkouB => SenkouBValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.Chinkou"/> value.
 	/// </summary>
-	public decimal? Chinkou => GetInnerDecimal(TypedIndicator.Chinkou);
+	public IIndicatorValue ChinkouValue => this[TypedIndicator.Chinkou];
+
+	/// <summary>
+	/// Gets the <see cref="Ichimoku.Chinkou"/> value.
+	/// </summary>
+	public decimal? Chinkou => ChinkouValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/KasePeakOscillator.cs
+++ b/Algo/Indicators/KasePeakOscillator.cs
@@ -193,10 +193,20 @@ public class KasePeakOscillatorValue(KasePeakOscillator indicator, DateTimeOffse
 	/// <summary>
 	/// Gets the <see cref="KasePeakOscillator.ShortTerm"/> value.
 	/// </summary>
-	public decimal? ShortTerm => GetInnerDecimal(TypedIndicator.ShortTerm);
+	public IIndicatorValue ShortTermValue => this[TypedIndicator.ShortTerm];
+
+	/// <summary>
+	/// Gets the <see cref="KasePeakOscillator.ShortTerm"/> value.
+	/// </summary>
+	public decimal? ShortTerm => ShortTermValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="KasePeakOscillator.LongTerm"/> value.
 	/// </summary>
-	public decimal? LongTerm => GetInnerDecimal(TypedIndicator.LongTerm);
+	public IIndicatorValue LongTermValue => this[TypedIndicator.LongTerm];
+
+	/// <summary>
+	/// Gets the <see cref="KasePeakOscillator.LongTerm"/> value.
+	/// </summary>
+	public decimal? LongTerm => LongTermValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/KeltnerChannels.cs
+++ b/Algo/Indicators/KeltnerChannels.cs
@@ -188,15 +188,30 @@ public class KeltnerChannelsValue(KeltnerChannels indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="KeltnerChannels.Middle"/> value.
 	/// </summary>
-	public decimal? Middle => GetInnerDecimal(TypedIndicator.Middle);
+	public IIndicatorValue MiddleValue => this[TypedIndicator.Middle];
+
+	/// <summary>
+	/// Gets the <see cref="KeltnerChannels.Middle"/> value.
+	/// </summary>
+	public decimal? Middle => MiddleValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="KeltnerChannels.Upper"/> value.
 	/// </summary>
-	public decimal? Upper => GetInnerDecimal(TypedIndicator.Upper);
+	public IIndicatorValue UpperValue => this[TypedIndicator.Upper];
+
+	/// <summary>
+	/// Gets the <see cref="KeltnerChannels.Upper"/> value.
+	/// </summary>
+	public decimal? Upper => UpperValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="KeltnerChannels.Lower"/> value.
 	/// </summary>
-	public decimal? Lower => GetInnerDecimal(TypedIndicator.Lower);
+	public IIndicatorValue LowerValue => this[TypedIndicator.Lower];
+
+	/// <summary>
+	/// Gets the <see cref="KeltnerChannels.Lower"/> value.
+	/// </summary>
+	public decimal? Lower => LowerValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/KlingerVolumeOscillator.cs
+++ b/Algo/Indicators/KlingerVolumeOscillator.cs
@@ -135,15 +135,30 @@ public class KlingerVolumeOscillatorValue(KlingerVolumeOscillator indicator, Dat
 	/// <summary>
 	/// Gets the short EMA value.
 	/// </summary>
-	public decimal? ShortEma => GetInnerDecimal(TypedIndicator.ShortEma);
+	public IIndicatorValue ShortEmaValue => this[TypedIndicator.ShortEma];
+
+	/// <summary>
+	/// Gets the short EMA value.
+	/// </summary>
+	public decimal? ShortEma => ShortEmaValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the long EMA value.
 	/// </summary>
-	public decimal? LongEma => GetInnerDecimal(TypedIndicator.LongEma);
+	public IIndicatorValue LongEmaValue => this[TypedIndicator.LongEma];
+
+	/// <summary>
+	/// Gets the long EMA value.
+	/// </summary>
+	public decimal? LongEma => LongEmaValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the oscillator value.
 	/// </summary>
-	public decimal? Oscillator => GetInnerDecimal(TypedIndicator);
+	public IIndicatorValue OscillatorValue => this[TypedIndicator];
+
+	/// <summary>
+	/// Gets the oscillator value.
+	/// </summary>
+	public decimal? Oscillator => OscillatorValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/KnowSureThing.cs
+++ b/Algo/Indicators/KnowSureThing.cs
@@ -129,10 +129,20 @@ public class KnowSureThingValue(KnowSureThing indicator, DateTimeOffset time) : 
 	/// <summary>
 	/// Gets the KST line value.
 	/// </summary>
-	public decimal? KstLine => GetInnerDecimal(TypedIndicator.KstLine);
+	public IIndicatorValue KstLineValue => this[TypedIndicator.KstLine];
+
+	/// <summary>
+	/// Gets the KST line value.
+	/// </summary>
+	public decimal? KstLine => KstLineValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the signal line value.
 	/// </summary>
-	public decimal? Signal => GetInnerDecimal(TypedIndicator.Signal);
+	public IIndicatorValue SignalValue => this[TypedIndicator.Signal];
+
+	/// <summary>
+	/// Gets the signal line value.
+	/// </summary>
+	public decimal? Signal => SignalValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/LinearRegression.cs
+++ b/Algo/Indicators/LinearRegression.cs
@@ -134,20 +134,40 @@ public class LinearRegressionValue(LinearRegression indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.LinearReg"/> value.
 	/// </summary>
-	public decimal? LinearReg => GetInnerDecimal(TypedIndicator.LinearReg);
+	public IIndicatorValue LinearRegValue => this[TypedIndicator.LinearReg];
+
+	/// <summary>
+	/// Gets the <see cref="LinearRegression.LinearReg"/> value.
+	/// </summary>
+	public decimal? LinearReg => LinearRegValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.RSquared"/> value.
 	/// </summary>
-	public decimal? RSquared => GetInnerDecimal(TypedIndicator.RSquared);
+	public IIndicatorValue RSquaredValue => this[TypedIndicator.RSquared];
+
+	/// <summary>
+	/// Gets the <see cref="LinearRegression.RSquared"/> value.
+	/// </summary>
+	public decimal? RSquared => RSquaredValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.LinearRegSlope"/> value.
 	/// </summary>
-	public decimal? LinearRegSlope => GetInnerDecimal(TypedIndicator.LinearRegSlope);
+	public IIndicatorValue LinearRegSlopeValue => this[TypedIndicator.LinearRegSlope];
+
+	/// <summary>
+	/// Gets the <see cref="LinearRegression.LinearRegSlope"/> value.
+	/// </summary>
+	public decimal? LinearRegSlope => LinearRegSlopeValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.StandardError"/> value.
 	/// </summary>
-	public decimal? StandardError => GetInnerDecimal(TypedIndicator.StandardError);
+	public IIndicatorValue StandardErrorValue => this[TypedIndicator.StandardError];
+
+	/// <summary>
+	/// Gets the <see cref="LinearRegression.StandardError"/> value.
+	/// </summary>
+	public decimal? StandardError => StandardErrorValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/MovingAverageConvergenceDivergenceHistogram.cs
+++ b/Algo/Indicators/MovingAverageConvergenceDivergenceHistogram.cs
@@ -93,10 +93,20 @@ public class MovingAverageConvergenceDivergenceHistogramValue(MovingAverageConve
 	/// <summary>
 	/// Gets the MACD value.
 	/// </summary>
-	public decimal? Macd => GetInnerDecimal(TypedIndicator.Macd);
+	public IIndicatorValue MacdValue => this[TypedIndicator.Macd];
+
+	/// <summary>
+	/// Gets the MACD value.
+	/// </summary>
+	public decimal? Macd => MacdValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the signal line value.
 	/// </summary>
-	public decimal? Signal => GetInnerDecimal(TypedIndicator.SignalMa);
+	public IIndicatorValue SignalValue => this[TypedIndicator.SignalMa];
+
+	/// <summary>
+	/// Gets the signal line value.
+	/// </summary>
+	public decimal? Signal => SignalValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/MovingAverageConvergenceDivergenceSignal.cs
+++ b/Algo/Indicators/MovingAverageConvergenceDivergenceSignal.cs
@@ -81,10 +81,20 @@ public class MovingAverageConvergenceDivergenceSignalValue(MovingAverageConverge
 	/// <summary>
 	/// Gets the MACD value.
 	/// </summary>
-	public decimal? Macd => GetInnerDecimal(TypedIndicator.Macd);
+	public IIndicatorValue MacdValue => this[TypedIndicator.Macd];
+
+	/// <summary>
+	/// Gets the MACD value.
+	/// </summary>
+	public decimal? Macd => MacdValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the signal line value.
 	/// </summary>
-	public decimal? Signal => GetInnerDecimal(TypedIndicator.SignalMa);
+	public IIndicatorValue SignalValue => this[TypedIndicator.SignalMa];
+
+	/// <summary>
+	/// Gets the signal line value.
+	/// </summary>
+	public decimal? Signal => SignalValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/MovingAverageRibbon.cs
+++ b/Algo/Indicators/MovingAverageRibbon.cs
@@ -149,5 +149,10 @@ public class MovingAverageRibbonValue(MovingAverageRibbon indicator, DateTimeOff
 	/// <summary>
 	/// Gets all moving average values.
 	/// </summary>
-	public decimal?[] Averages => [.. TypedIndicator.InnerIndicators.Select(GetInnerDecimal)];
+	public IIndicatorValue[] AveragesValues => [.. TypedIndicator.InnerIndicators.Select(ind => this[ind])];
+
+	/// <summary>
+	/// Gets all moving average values.
+	/// </summary>
+	public decimal?[] Averages => [.. AveragesValues.Select(v => v.ToNullableDecimal())];
 }

--- a/Algo/Indicators/PercentagePriceOscillator.cs
+++ b/Algo/Indicators/PercentagePriceOscillator.cs
@@ -140,10 +140,20 @@ public class PercentagePriceOscillatorValue(PercentagePriceOscillator indicator,
 	/// <summary>
 	/// Gets the short EMA value.
 	/// </summary>
-	public decimal? ShortEma => GetInnerDecimal(TypedIndicator.ShortEma);
+	public IIndicatorValue ShortEmaValue => this[TypedIndicator.ShortEma];
+
+	/// <summary>
+	/// Gets the short EMA value.
+	/// </summary>
+	public decimal? ShortEma => ShortEmaValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the long EMA value.
 	/// </summary>
-	public decimal? LongEma => GetInnerDecimal(TypedIndicator.LongEma);
+	public IIndicatorValue LongEmaValue => this[TypedIndicator.LongEma];
+
+	/// <summary>
+	/// Gets the long EMA value.
+	/// </summary>
+	public decimal? LongEma => LongEmaValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/PercentageVolumeOscillator.cs
+++ b/Algo/Indicators/PercentageVolumeOscillator.cs
@@ -145,10 +145,20 @@ public class PercentageVolumeOscillatorValue(PercentageVolumeOscillator indicato
 	/// <summary>
 	/// Gets the short EMA value.
 	/// </summary>
-	public decimal? ShortEma => GetInnerDecimal(TypedIndicator.ShortEma);
+	public IIndicatorValue ShortEmaValue => this[TypedIndicator.ShortEma];
+
+	/// <summary>
+	/// Gets the short EMA value.
+	/// </summary>
+	public decimal? ShortEma => ShortEmaValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the long EMA value.
 	/// </summary>
-	public decimal? LongEma => GetInnerDecimal(TypedIndicator.LongEma);
+	public IIndicatorValue LongEmaValue => this[TypedIndicator.LongEma];
+
+	/// <summary>
+	/// Gets the long EMA value.
+	/// </summary>
+	public decimal? LongEma => LongEmaValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/PivotPoints.cs
+++ b/Algo/Indicators/PivotPoints.cs
@@ -109,25 +109,50 @@ public class PivotPointsValue(PivotPoints indicator, DateTimeOffset time) : Comp
 	/// <summary>
 	/// Gets the Pivot Point value.
 	/// </summary>
-	public decimal? PivotPoint => GetInnerDecimal(TypedIndicator.PivotPoint);
+	public IIndicatorValue PivotPointValue => this[TypedIndicator.PivotPoint];
+
+	/// <summary>
+	/// Gets the Pivot Point value.
+	/// </summary>
+	public decimal? PivotPoint => PivotPointValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the R1 value.
 	/// </summary>
-	public decimal? R1 => GetInnerDecimal(TypedIndicator.R1);
+	public IIndicatorValue R1Value => this[TypedIndicator.R1];
+
+	/// <summary>
+	/// Gets the R1 value.
+	/// </summary>
+	public decimal? R1 => R1Value.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the R2 value.
 	/// </summary>
-	public decimal? R2 => GetInnerDecimal(TypedIndicator.R2);
+	public IIndicatorValue R2Value => this[TypedIndicator.R2];
+
+	/// <summary>
+	/// Gets the R2 value.
+	/// </summary>
+	public decimal? R2 => R2Value.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the S1 value.
 	/// </summary>
-	public decimal? S1 => GetInnerDecimal(TypedIndicator.S1);
+	public IIndicatorValue S1Value => this[TypedIndicator.S1];
+
+	/// <summary>
+	/// Gets the S1 value.
+	/// </summary>
+	public decimal? S1 => S1Value.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the S2 value.
 	/// </summary>
-	public decimal? S2 => GetInnerDecimal(TypedIndicator.S2);
+	public IIndicatorValue S2Value => this[TypedIndicator.S2];
+
+	/// <summary>
+	/// Gets the S2 value.
+	/// </summary>
+	public decimal? S2 => S2Value.ToNullableDecimal();
 }

--- a/Algo/Indicators/PriceChannels.cs
+++ b/Algo/Indicators/PriceChannels.cs
@@ -110,10 +110,20 @@ public class PriceChannelsValue(PriceChannels indicator, DateTimeOffset time) : 
 	/// <summary>
 	/// Gets the upper channel value.
 	/// </summary>
-	public decimal? UpperChannel => GetInnerDecimal(TypedIndicator.UpperChannel);
+	public IIndicatorValue UpperChannelValue => this[TypedIndicator.UpperChannel];
+
+	/// <summary>
+	/// Gets the upper channel value.
+	/// </summary>
+	public decimal? UpperChannel => UpperChannelValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the lower channel value.
 	/// </summary>
-	public decimal? LowerChannel => GetInnerDecimal(TypedIndicator.LowerChannel);
+	public IIndicatorValue LowerChannelValue => this[TypedIndicator.LowerChannel];
+
+	/// <summary>
+	/// Gets the lower channel value.
+	/// </summary>
+	public decimal? LowerChannel => LowerChannelValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/RainbowCharts.cs
+++ b/Algo/Indicators/RainbowCharts.cs
@@ -88,5 +88,10 @@ public class RainbowChartsValue(RainbowCharts indicator, DateTimeOffset time) : 
 	/// <summary>
 	/// Gets values of all moving averages.
 	/// </summary>
-	public decimal?[] Averages => [.. TypedIndicator.InnerIndicators.Select(GetInnerDecimal)];
+	public IIndicatorValue[] AveragesValues => [.. TypedIndicator.InnerIndicators.Select(ind => this[ind])];
+
+	/// <summary>
+	/// Gets values of all moving averages.
+	/// </summary>
+	public decimal?[] Averages => [.. AveragesValues.Select(v => v.ToNullableDecimal())];
 }

--- a/Algo/Indicators/RelativeVigorIndex.cs
+++ b/Algo/Indicators/RelativeVigorIndex.cs
@@ -82,10 +82,20 @@ public class RelativeVigorIndexValue(RelativeVigorIndex indicator, DateTimeOffse
 	/// <summary>
 	/// Gets the <see cref="RelativeVigorIndex.Average"/> value.
 	/// </summary>
-	public decimal? Average => GetInnerDecimal(TypedIndicator.Average);
+	public IIndicatorValue AverageValue => this[TypedIndicator.Average];
+
+	/// <summary>
+	/// Gets the <see cref="RelativeVigorIndex.Average"/> value.
+	/// </summary>
+	public decimal? Average => AverageValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="RelativeVigorIndex.Signal"/> value.
 	/// </summary>
-	public decimal? Signal => GetInnerDecimal(TypedIndicator.Signal);
+	public IIndicatorValue SignalValue => this[TypedIndicator.Signal];
+
+	/// <summary>
+	/// Gets the <see cref="RelativeVigorIndex.Signal"/> value.
+	/// </summary>
+	public decimal? Signal => SignalValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/SineWave.cs
+++ b/Algo/Indicators/SineWave.cs
@@ -141,10 +141,20 @@ public class SineWaveValue(SineWave indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the main line value.
 	/// </summary>
-	public decimal? Main => GetInnerDecimal(TypedIndicator.Main);
+	public IIndicatorValue MainValue => this[TypedIndicator.Main];
+
+	/// <summary>
+	/// Gets the main line value.
+	/// </summary>
+	public decimal? Main => MainValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the lead line value.
 	/// </summary>
-	public decimal? Lead => GetInnerDecimal(TypedIndicator.Lead);
+	public IIndicatorValue LeadValue => this[TypedIndicator.Lead];
+
+	/// <summary>
+	/// Gets the lead line value.
+	/// </summary>
+	public decimal? Lead => LeadValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/StochasticOscillator.cs
+++ b/Algo/Indicators/StochasticOscillator.cs
@@ -71,10 +71,20 @@ public class StochasticOscillatorValue(StochasticOscillator indicator, DateTimeO
 	/// <summary>
 	/// Gets the %K value.
 	/// </summary>
-	public decimal? K => GetInnerDecimal(TypedIndicator.K);
+	public IIndicatorValue KValue => this[TypedIndicator.K];
+
+	/// <summary>
+	/// Gets the %K value.
+	/// </summary>
+	public decimal? K => KValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the %D value.
 	/// </summary>
-	public decimal? D => GetInnerDecimal(TypedIndicator.D);
+	public IIndicatorValue DValue => this[TypedIndicator.D];
+
+	/// <summary>
+	/// Gets the %D value.
+	/// </summary>
+	public decimal? D => DValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/VortexIndicator.cs
+++ b/Algo/Indicators/VortexIndicator.cs
@@ -205,10 +205,20 @@ public class VortexIndicatorValue(VortexIndicator indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="VortexIndicator.PlusVi"/> value.
 	/// </summary>
-	public decimal? PlusVi => GetInnerDecimal(TypedIndicator.PlusVi);
+	public IIndicatorValue PlusViValue => this[TypedIndicator.PlusVi];
+
+	/// <summary>
+	/// Gets the <see cref="VortexIndicator.PlusVi"/> value.
+	/// </summary>
+	public decimal? PlusVi => PlusViValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the <see cref="VortexIndicator.MinusVi"/> value.
 	/// </summary>
-	public decimal? MinusVi => GetInnerDecimal(TypedIndicator.MinusVi);
+	public IIndicatorValue MinusViValue => this[TypedIndicator.MinusVi];
+
+	/// <summary>
+	/// Gets the <see cref="VortexIndicator.MinusVi"/> value.
+	/// </summary>
+	public decimal? MinusVi => MinusViValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/WaveTrendOscillator.cs
+++ b/Algo/Indicators/WaveTrendOscillator.cs
@@ -217,10 +217,20 @@ public class WaveTrendOscillatorValue(WaveTrendOscillator indicator, DateTimeOff
 	/// <summary>
 	/// Gets the first Wavetrend line value.
 	/// </summary>
-	public decimal? Wt1 => GetInnerDecimal(TypedIndicator.Wt1);
+	public IIndicatorValue Wt1Value => this[TypedIndicator.Wt1];
+
+	/// <summary>
+	/// Gets the first Wavetrend line value.
+	/// </summary>
+	public decimal? Wt1 => Wt1Value.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the second Wavetrend line value.
 	/// </summary>
-	public decimal? Wt2 => GetInnerDecimal(TypedIndicator.Wt2);
+	public IIndicatorValue Wt2Value => this[TypedIndicator.Wt2];
+
+	/// <summary>
+	/// Gets the second Wavetrend line value.
+	/// </summary>
+	public decimal? Wt2 => Wt2Value.ToNullableDecimal();
 }

--- a/Algo/Indicators/WoodiesCCI.cs
+++ b/Algo/Indicators/WoodiesCCI.cs
@@ -90,10 +90,20 @@ public class WoodiesCCIValue(WoodiesCCI indicator, DateTimeOffset time) : Comple
 	/// <summary>
 	/// Gets the CCI value.
 	/// </summary>
-	public decimal? Cci => GetInnerDecimal(TypedIndicator.Cci);
+	public IIndicatorValue CciValue => this[TypedIndicator.Cci];
+
+	/// <summary>
+	/// Gets the CCI value.
+	/// </summary>
+	public decimal? Cci => CciValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the SMA value.
 	/// </summary>
-	public decimal? Sma => GetInnerDecimal(TypedIndicator.Sma);
+	public IIndicatorValue SmaValue => this[TypedIndicator.Sma];
+
+	/// <summary>
+	/// Gets the SMA value.
+	/// </summary>
+	public decimal? Sma => SmaValue.ToNullableDecimal();
 }


### PR DESCRIPTION
## Summary
- add accessors returning `IIndicatorValue` for each complex indicator
- base decimal properties now convert from those accessors
- convert indentation to tabs

## Testing
- `dotnet build StockSharp_Tests.sln --configuration Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test StockSharp_Tests.sln --configuration Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687525e6d7288323b5cee7f25e05bd1d