### PR TITLE
Add Browsable attribute for non-indicator properties

### DIFF
--- a/Algo/Indicators/AdaptivePriceZone.cs
+++ b/Algo/Indicators/AdaptivePriceZone.cs
@@ -197,15 +197,18 @@ public class AdaptivePriceZoneValue(AdaptivePriceZone indicator, DateTimeOffset 
 	/// <summary>
 	/// Gets the moving average value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? MovingAverage => MovingAverageValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the upper band value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? UpperBand => UpperBandValue.ToNullableDecimal();
 
 	/// <summary>
 	/// Gets the lower band value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LowerBand => LowerBandValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/Alligator.cs
+++ b/Algo/Indicators/Alligator.cs
@@ -100,6 +100,7 @@ public class AlligatorValue(Alligator indicator, DateTimeOffset time) : ComplexI
 	/// <summary>
 	/// Gets the <see cref="Alligator.Jaw"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Jaw => JawValue.ToNullableDecimal();
 
 	/// <summary>
@@ -110,6 +111,7 @@ public class AlligatorValue(Alligator indicator, DateTimeOffset time) : ComplexI
 	/// <summary>
 	/// Gets the <see cref="Alligator.Teeth"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Teeth => TeethValue.ToNullableDecimal();
 
 	/// <summary>
@@ -120,5 +122,6 @@ public class AlligatorValue(Alligator indicator, DateTimeOffset time) : ComplexI
 	/// <summary>
 	/// Gets the <see cref="Alligator.Lips"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Lips => LipsValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/Aroon.cs
+++ b/Algo/Indicators/Aroon.cs
@@ -285,6 +285,7 @@ public class AroonValue(Aroon indicator, DateTimeOffset time) : ComplexIndicator
 	/// <summary>
 	/// Gets the <see cref="Aroon.Up"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Up => UpValue.ToNullableDecimal();
 
 	/// <summary>
@@ -295,5 +296,6 @@ public class AroonValue(Aroon indicator, DateTimeOffset time) : ComplexIndicator
 	/// <summary>
 	/// Gets the <see cref="Aroon.Down"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Down => DownValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/AverageDirectionalIndex.cs
+++ b/Algo/Indicators/AverageDirectionalIndex.cs
@@ -108,6 +108,7 @@ public class AverageDirectionalIndexValue(AverageDirectionalIndex indicator, Dat
 	/// <summary>
 	/// Gets the <see cref="AverageDirectionalIndex.Dx"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public DirectionalIndexValue Dx => (DirectionalIndexValue)DxValue;
 	
 	/// <summary>
@@ -118,5 +119,6 @@ public class AverageDirectionalIndexValue(AverageDirectionalIndex indicator, Dat
 	/// <summary>
 	/// Gets the <see cref="AverageDirectionalIndex.MovingAverage"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? MovingAverage => MovingAverageValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/BollingerBands.cs
+++ b/Algo/Indicators/BollingerBands.cs
@@ -149,6 +149,7 @@ public class BollingerBandsValue(BollingerBands indicator, DateTimeOffset time) 
 	/// <summary>
 	/// Gets the <see cref="BollingerBands.MovingAverage"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? MovingAverage => MovingAverageValue.ToNullableDecimal();
 
 	/// <summary>
@@ -159,6 +160,7 @@ public class BollingerBandsValue(BollingerBands indicator, DateTimeOffset time) 
 	/// <summary>
 	/// Gets the <see cref="BollingerBands.UpBand"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? UpBand => UpBandValue.ToNullableDecimal();
 
 	/// <summary>
@@ -169,5 +171,6 @@ public class BollingerBandsValue(BollingerBands indicator, DateTimeOffset time) 
 	/// <summary>
 	/// Gets the <see cref="BollingerBands.LowBand"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LowBand => LowBandValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/ChandeKrollStop.cs
+++ b/Algo/Indicators/ChandeKrollStop.cs
@@ -186,6 +186,7 @@ public class ChandeKrollStopValue(ChandeKrollStop indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the highest stop line.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Highest => HighestValue.ToNullableDecimal();
 
 	/// <summary>
@@ -196,5 +197,6 @@ public class ChandeKrollStopValue(ChandeKrollStop indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the lowest stop line.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Lowest => LowestValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/CompositeMomentum.cs
+++ b/Algo/Indicators/CompositeMomentum.cs
@@ -162,6 +162,7 @@ public class CompositeMomentumValue(CompositeMomentum indicator, DateTimeOffset 
 	/// <summary>
 	/// Gets the SMA value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Sma => SmaValue.ToNullableDecimal();
 
 	/// <summary>
@@ -172,5 +173,6 @@ public class CompositeMomentumValue(CompositeMomentum indicator, DateTimeOffset 
 	/// <summary>
 	/// Gets the composite momentum line.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? CompositeLine => CompositeLineValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/ConnorsRSI.cs
+++ b/Algo/Indicators/ConnorsRSI.cs
@@ -247,6 +247,7 @@ public class ConnorsRSIValue(ConnorsRSI indicator, DateTimeOffset time) : Comple
 	/// <summary>
 	/// Gets the RSI component.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Rsi => RsiValue.ToNullableDecimal();
 
 	/// <summary>
@@ -257,6 +258,7 @@ public class ConnorsRSIValue(ConnorsRSI indicator, DateTimeOffset time) : Comple
 	/// <summary>
 	/// Gets the UpDown RSI component.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? UpDownRsi => UpDownRsiValue.ToNullableDecimal();
 
 	/// <summary>
@@ -267,6 +269,7 @@ public class ConnorsRSIValue(ConnorsRSI indicator, DateTimeOffset time) : Comple
 	/// <summary>
 	/// Gets the ROC RSI component.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? RocRsi => RocRsiValue.ToNullableDecimal();
 
 	/// <summary>
@@ -277,5 +280,6 @@ public class ConnorsRSIValue(ConnorsRSI indicator, DateTimeOffset time) : Comple
 	/// <summary>
 	/// Gets the composite RSI line.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? CrsiLine => CrsiLineValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/ConstanceBrownCompositeIndex.cs
+++ b/Algo/Indicators/ConstanceBrownCompositeIndex.cs
@@ -169,6 +169,7 @@ public class ConstanceBrownCompositeIndexValue(ConstanceBrownCompositeIndex indi
 	/// <summary>
 	/// Gets the RSI component.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Rsi => RsiValue.ToNullableDecimal();
 
 	/// <summary>
@@ -179,6 +180,7 @@ public class ConstanceBrownCompositeIndexValue(ConstanceBrownCompositeIndex indi
 	/// <summary>
 	/// Gets the stochastic component.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Stoch => StochValue.ToNullableDecimal();
 
 	/// <summary>
@@ -189,5 +191,6 @@ public class ConstanceBrownCompositeIndexValue(ConstanceBrownCompositeIndex indi
 	/// <summary>
 	/// Gets the composite index line.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? CompositeIndexLine => CompositeIndexLineValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/DirectionalIndex.cs
+++ b/Algo/Indicators/DirectionalIndex.cs
@@ -124,6 +124,7 @@ public class DirectionalIndexValue(DirectionalIndex indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="DirectionalIndex.Plus"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Plus => PlusValue.ToNullableDecimal();
 	
 	/// <summary>
@@ -134,5 +135,6 @@ public class DirectionalIndexValue(DirectionalIndex indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="DirectionalIndex.Minus"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Minus => MinusValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/DonchianChannels.cs
+++ b/Algo/Indicators/DonchianChannels.cs
@@ -141,6 +141,7 @@ public class DonchianChannelsValue(DonchianChannels indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="DonchianChannels.UpperBand"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? UpperBand => UpperBandValue.ToNullableDecimal();
 
 	/// <summary>
@@ -151,6 +152,7 @@ public class DonchianChannelsValue(DonchianChannels indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="DonchianChannels.LowerBand"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LowerBand => LowerBandValue.ToNullableDecimal();
 
 	/// <summary>
@@ -161,5 +163,6 @@ public class DonchianChannelsValue(DonchianChannels indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="DonchianChannels.Middle"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Middle => MiddleValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/EhlersFisherTransform.cs
+++ b/Algo/Indicators/EhlersFisherTransform.cs
@@ -181,6 +181,7 @@ public class EhlersFisherTransformValue(EhlersFisherTransform indicator, DateTim
 	/// <summary>
 	/// Gets the main line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? MainLine => MainLineValue.ToNullableDecimal();
 
 	/// <summary>
@@ -191,5 +192,6 @@ public class EhlersFisherTransformValue(EhlersFisherTransform indicator, DateTim
 	/// <summary>
 	/// Gets the trigger line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? TriggerLine => TriggerLineValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/Envelope.cs
+++ b/Algo/Indicators/Envelope.cs
@@ -146,6 +146,7 @@ public class EnvelopeValue(Envelope indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Envelope.Middle"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Middle => MiddleValue.ToNullableDecimal();
 
 	/// <summary>
@@ -156,6 +157,7 @@ public class EnvelopeValue(Envelope indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Envelope.Upper"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Upper => UpperValue.ToNullableDecimal();
 
 	/// <summary>
@@ -166,5 +168,6 @@ public class EnvelopeValue(Envelope indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Envelope.Lower"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Lower => LowerValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/FibonacciRetracement.cs
+++ b/Algo/Indicators/FibonacciRetracement.cs
@@ -151,10 +151,12 @@ public class FibonacciRetracementValue(FibonacciRetracement indicator, DateTimeO
 	/// <summary>
 	/// Gets all level values.
 	/// </summary>
+	[Browsable(false)]
 	public IIndicatorValue[] LevelsValues => [.. TypedIndicator.Levels.Select(ind => this[ind])];
 
 	/// <summary>
 	/// Gets all level values.
 	/// </summary>
+	[Browsable(false)]
 	public decimal?[] Levels => [.. LevelsValues.Select(v => v.ToNullableDecimal())];
 }

--- a/Algo/Indicators/Fractals.cs
+++ b/Algo/Indicators/Fractals.cs
@@ -13,16 +13,19 @@ public class FractalsValue(Fractals fractals, DateTimeOffset time) : ComplexIndi
 	/// <summary>
 	/// Has pattern.
 	/// </summary>
+	[Browsable(false)]
 	public bool HasPattern { get; private set; }
 
 	/// <summary>
 	/// Has up.
 	/// </summary>
+	[Browsable(false)]
 	public bool HasUp { get; private set; }
 
 	/// <summary>
 	/// Has down.
 	/// </summary>
+	[Browsable(false)]
 	public bool HasDown { get; private set; }
 
 	/// <summary>
@@ -33,6 +36,7 @@ public class FractalsValue(Fractals fractals, DateTimeOffset time) : ComplexIndi
 	/// <summary>
 	/// Gets the <see cref="Fractals.Up"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Up => UpValue.ToNullableDecimal();
 
 	/// <summary>
@@ -43,6 +47,7 @@ public class FractalsValue(Fractals fractals, DateTimeOffset time) : ComplexIndi
 	/// <summary>
 	/// Gets the <see cref="Fractals.Down"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Down => DownValue.ToNullableDecimal();
 
 	/// <summary>

--- a/Algo/Indicators/GatorOscillator.cs
+++ b/Algo/Indicators/GatorOscillator.cs
@@ -90,6 +90,7 @@ public class GatorOscillatorValue(GatorOscillator indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="GatorOscillator.Histogram1"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Histogram1 => Histogram1Value.ToNullableDecimal();
 
 	/// <summary>
@@ -100,5 +101,6 @@ public class GatorOscillatorValue(GatorOscillator indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="GatorOscillator.Histogram2"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Histogram2 => Histogram2Value.ToNullableDecimal();
 }

--- a/Algo/Indicators/GuppyMultipleMovingAverage.cs
+++ b/Algo/Indicators/GuppyMultipleMovingAverage.cs
@@ -40,10 +40,12 @@ public class GuppyMultipleMovingAverageValue(GuppyMultipleMovingAverage indicato
 	/// <summary>
 	/// Gets values of all moving averages.
 	/// </summary>
+	[Browsable(false)]
 	public IIndicatorValue[] AveragesValues => [.. TypedIndicator.InnerIndicators.Select(ind => this[ind])];
 
 	/// <summary>
 	/// Gets values of all moving averages.
 	/// </summary>
+	[Browsable(false)]
 	public decimal?[] Averages => [.. AveragesValues.Select(v => v.ToNullableDecimal())];
 }

--- a/Algo/Indicators/Ichimoku.cs
+++ b/Algo/Indicators/Ichimoku.cs
@@ -117,6 +117,7 @@ public class IchimokuValue(Ichimoku indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.Tenkan"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Tenkan => TenkanValue.ToNullableDecimal();
 
 	/// <summary>
@@ -127,6 +128,7 @@ public class IchimokuValue(Ichimoku indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.Kijun"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Kijun => KijunValue.ToNullableDecimal();
 
 	/// <summary>
@@ -137,6 +139,7 @@ public class IchimokuValue(Ichimoku indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.SenkouA"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? SenkouA => SenkouAValue.ToNullableDecimal();
 
 	/// <summary>
@@ -147,6 +150,7 @@ public class IchimokuValue(Ichimoku indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.SenkouB"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? SenkouB => SenkouBValue.ToNullableDecimal();
 
 	/// <summary>
@@ -157,5 +161,6 @@ public class IchimokuValue(Ichimoku indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the <see cref="Ichimoku.Chinkou"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Chinkou => ChinkouValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/KasePeakOscillator.cs
+++ b/Algo/Indicators/KasePeakOscillator.cs
@@ -198,6 +198,7 @@ public class KasePeakOscillatorValue(KasePeakOscillator indicator, DateTimeOffse
 	/// <summary>
 	/// Gets the <see cref="KasePeakOscillator.ShortTerm"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? ShortTerm => ShortTermValue.ToNullableDecimal();
 
 	/// <summary>
@@ -208,5 +209,6 @@ public class KasePeakOscillatorValue(KasePeakOscillator indicator, DateTimeOffse
 	/// <summary>
 	/// Gets the <see cref="KasePeakOscillator.LongTerm"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LongTerm => LongTermValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/KeltnerChannels.cs
+++ b/Algo/Indicators/KeltnerChannels.cs
@@ -193,6 +193,7 @@ public class KeltnerChannelsValue(KeltnerChannels indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="KeltnerChannels.Middle"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Middle => MiddleValue.ToNullableDecimal();
 
 	/// <summary>
@@ -203,6 +204,7 @@ public class KeltnerChannelsValue(KeltnerChannels indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="KeltnerChannels.Upper"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Upper => UpperValue.ToNullableDecimal();
 
 	/// <summary>
@@ -213,5 +215,6 @@ public class KeltnerChannelsValue(KeltnerChannels indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="KeltnerChannels.Lower"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Lower => LowerValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/KlingerVolumeOscillator.cs
+++ b/Algo/Indicators/KlingerVolumeOscillator.cs
@@ -140,6 +140,7 @@ public class KlingerVolumeOscillatorValue(KlingerVolumeOscillator indicator, Dat
 	/// <summary>
 	/// Gets the short EMA value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? ShortEma => ShortEmaValue.ToNullableDecimal();
 
 	/// <summary>
@@ -150,6 +151,7 @@ public class KlingerVolumeOscillatorValue(KlingerVolumeOscillator indicator, Dat
 	/// <summary>
 	/// Gets the long EMA value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LongEma => LongEmaValue.ToNullableDecimal();
 
 	/// <summary>
@@ -160,5 +162,6 @@ public class KlingerVolumeOscillatorValue(KlingerVolumeOscillator indicator, Dat
 	/// <summary>
 	/// Gets the oscillator value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Oscillator => OscillatorValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/KnowSureThing.cs
+++ b/Algo/Indicators/KnowSureThing.cs
@@ -134,6 +134,7 @@ public class KnowSureThingValue(KnowSureThing indicator, DateTimeOffset time) : 
 	/// <summary>
 	/// Gets the KST line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? KstLine => KstLineValue.ToNullableDecimal();
 
 	/// <summary>
@@ -144,5 +145,6 @@ public class KnowSureThingValue(KnowSureThing indicator, DateTimeOffset time) : 
 	/// <summary>
 	/// Gets the signal line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Signal => SignalValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/LinearRegression.cs
+++ b/Algo/Indicators/LinearRegression.cs
@@ -139,6 +139,7 @@ public class LinearRegressionValue(LinearRegression indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.LinearReg"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LinearReg => LinearRegValue.ToNullableDecimal();
 
 	/// <summary>
@@ -149,6 +150,7 @@ public class LinearRegressionValue(LinearRegression indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.RSquared"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? RSquared => RSquaredValue.ToNullableDecimal();
 
 	/// <summary>
@@ -159,6 +161,7 @@ public class LinearRegressionValue(LinearRegression indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.LinearRegSlope"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LinearRegSlope => LinearRegSlopeValue.ToNullableDecimal();
 
 	/// <summary>
@@ -169,5 +172,6 @@ public class LinearRegressionValue(LinearRegression indicator, DateTimeOffset ti
 	/// <summary>
 	/// Gets the <see cref="LinearRegression.StandardError"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? StandardError => StandardErrorValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/MovingAverageConvergenceDivergenceHistogram.cs
+++ b/Algo/Indicators/MovingAverageConvergenceDivergenceHistogram.cs
@@ -98,6 +98,7 @@ public class MovingAverageConvergenceDivergenceHistogramValue(MovingAverageConve
 	/// <summary>
 	/// Gets the MACD value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Macd => MacdValue.ToNullableDecimal();
 
 	/// <summary>
@@ -108,5 +109,6 @@ public class MovingAverageConvergenceDivergenceHistogramValue(MovingAverageConve
 	/// <summary>
 	/// Gets the signal line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Signal => SignalValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/MovingAverageConvergenceDivergenceSignal.cs
+++ b/Algo/Indicators/MovingAverageConvergenceDivergenceSignal.cs
@@ -86,6 +86,7 @@ public class MovingAverageConvergenceDivergenceSignalValue(MovingAverageConverge
 	/// <summary>
 	/// Gets the MACD value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Macd => MacdValue.ToNullableDecimal();
 
 	/// <summary>
@@ -96,5 +97,6 @@ public class MovingAverageConvergenceDivergenceSignalValue(MovingAverageConverge
 	/// <summary>
 	/// Gets the signal line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Signal => SignalValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/MovingAverageRibbon.cs
+++ b/Algo/Indicators/MovingAverageRibbon.cs
@@ -149,10 +149,12 @@ public class MovingAverageRibbonValue(MovingAverageRibbon indicator, DateTimeOff
 	/// <summary>
 	/// Gets all moving average values.
 	/// </summary>
+	[Browsable(false)]
 	public IIndicatorValue[] AveragesValues => [.. TypedIndicator.InnerIndicators.Select(ind => this[ind])];
 
 	/// <summary>
 	/// Gets all moving average values.
 	/// </summary>
+	[Browsable(false)]
 	public decimal?[] Averages => [.. AveragesValues.Select(v => v.ToNullableDecimal())];
 }

--- a/Algo/Indicators/PercentagePriceOscillator.cs
+++ b/Algo/Indicators/PercentagePriceOscillator.cs
@@ -145,6 +145,7 @@ public class PercentagePriceOscillatorValue(PercentagePriceOscillator indicator,
 	/// <summary>
 	/// Gets the short EMA value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? ShortEma => ShortEmaValue.ToNullableDecimal();
 
 	/// <summary>
@@ -155,5 +156,6 @@ public class PercentagePriceOscillatorValue(PercentagePriceOscillator indicator,
 	/// <summary>
 	/// Gets the long EMA value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LongEma => LongEmaValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/PercentageVolumeOscillator.cs
+++ b/Algo/Indicators/PercentageVolumeOscillator.cs
@@ -150,6 +150,7 @@ public class PercentageVolumeOscillatorValue(PercentageVolumeOscillator indicato
 	/// <summary>
 	/// Gets the short EMA value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? ShortEma => ShortEmaValue.ToNullableDecimal();
 
 	/// <summary>
@@ -160,5 +161,6 @@ public class PercentageVolumeOscillatorValue(PercentageVolumeOscillator indicato
 	/// <summary>
 	/// Gets the long EMA value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LongEma => LongEmaValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/PivotPoints.cs
+++ b/Algo/Indicators/PivotPoints.cs
@@ -114,6 +114,7 @@ public class PivotPointsValue(PivotPoints indicator, DateTimeOffset time) : Comp
 	/// <summary>
 	/// Gets the Pivot Point value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? PivotPoint => PivotPointValue.ToNullableDecimal();
 
 	/// <summary>
@@ -124,6 +125,7 @@ public class PivotPointsValue(PivotPoints indicator, DateTimeOffset time) : Comp
 	/// <summary>
 	/// Gets the R1 value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? R1 => R1Value.ToNullableDecimal();
 
 	/// <summary>
@@ -134,6 +136,7 @@ public class PivotPointsValue(PivotPoints indicator, DateTimeOffset time) : Comp
 	/// <summary>
 	/// Gets the R2 value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? R2 => R2Value.ToNullableDecimal();
 
 	/// <summary>
@@ -144,6 +147,7 @@ public class PivotPointsValue(PivotPoints indicator, DateTimeOffset time) : Comp
 	/// <summary>
 	/// Gets the S1 value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? S1 => S1Value.ToNullableDecimal();
 
 	/// <summary>
@@ -154,5 +158,6 @@ public class PivotPointsValue(PivotPoints indicator, DateTimeOffset time) : Comp
 	/// <summary>
 	/// Gets the S2 value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? S2 => S2Value.ToNullableDecimal();
 }

--- a/Algo/Indicators/PriceChannels.cs
+++ b/Algo/Indicators/PriceChannels.cs
@@ -115,6 +115,7 @@ public class PriceChannelsValue(PriceChannels indicator, DateTimeOffset time) : 
 	/// <summary>
 	/// Gets the upper channel value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? UpperChannel => UpperChannelValue.ToNullableDecimal();
 
 	/// <summary>
@@ -125,5 +126,6 @@ public class PriceChannelsValue(PriceChannels indicator, DateTimeOffset time) : 
 	/// <summary>
 	/// Gets the lower channel value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? LowerChannel => LowerChannelValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/RainbowCharts.cs
+++ b/Algo/Indicators/RainbowCharts.cs
@@ -88,10 +88,12 @@ public class RainbowChartsValue(RainbowCharts indicator, DateTimeOffset time) : 
 	/// <summary>
 	/// Gets values of all moving averages.
 	/// </summary>
+	[Browsable(false)]
 	public IIndicatorValue[] AveragesValues => [.. TypedIndicator.InnerIndicators.Select(ind => this[ind])];
 
 	/// <summary>
 	/// Gets values of all moving averages.
 	/// </summary>
+	[Browsable(false)]
 	public decimal?[] Averages => [.. AveragesValues.Select(v => v.ToNullableDecimal())];
 }

--- a/Algo/Indicators/RelativeVigorIndex.cs
+++ b/Algo/Indicators/RelativeVigorIndex.cs
@@ -87,6 +87,7 @@ public class RelativeVigorIndexValue(RelativeVigorIndex indicator, DateTimeOffse
 	/// <summary>
 	/// Gets the <see cref="RelativeVigorIndex.Average"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Average => AverageValue.ToNullableDecimal();
 
 	/// <summary>
@@ -97,5 +98,6 @@ public class RelativeVigorIndexValue(RelativeVigorIndex indicator, DateTimeOffse
 	/// <summary>
 	/// Gets the <see cref="RelativeVigorIndex.Signal"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Signal => SignalValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/SineWave.cs
+++ b/Algo/Indicators/SineWave.cs
@@ -146,6 +146,7 @@ public class SineWaveValue(SineWave indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the main line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Main => MainValue.ToNullableDecimal();
 
 	/// <summary>
@@ -156,5 +157,6 @@ public class SineWaveValue(SineWave indicator, DateTimeOffset time) : ComplexInd
 	/// <summary>
 	/// Gets the lead line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Lead => LeadValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/StochasticOscillator.cs
+++ b/Algo/Indicators/StochasticOscillator.cs
@@ -76,6 +76,7 @@ public class StochasticOscillatorValue(StochasticOscillator indicator, DateTimeO
 	/// <summary>
 	/// Gets the %K value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? K => KValue.ToNullableDecimal();
 
 	/// <summary>
@@ -86,5 +87,6 @@ public class StochasticOscillatorValue(StochasticOscillator indicator, DateTimeO
 	/// <summary>
 	/// Gets the %D value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? D => DValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/VortexIndicator.cs
+++ b/Algo/Indicators/VortexIndicator.cs
@@ -210,6 +210,7 @@ public class VortexIndicatorValue(VortexIndicator indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="VortexIndicator.PlusVi"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? PlusVi => PlusViValue.ToNullableDecimal();
 
 	/// <summary>
@@ -220,5 +221,6 @@ public class VortexIndicatorValue(VortexIndicator indicator, DateTimeOffset time
 	/// <summary>
 	/// Gets the <see cref="VortexIndicator.MinusVi"/> value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? MinusVi => MinusViValue.ToNullableDecimal();
 }

--- a/Algo/Indicators/WaveTrendOscillator.cs
+++ b/Algo/Indicators/WaveTrendOscillator.cs
@@ -222,6 +222,7 @@ public class WaveTrendOscillatorValue(WaveTrendOscillator indicator, DateTimeOff
 	/// <summary>
 	/// Gets the first Wavetrend line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Wt1 => Wt1Value.ToNullableDecimal();
 
 	/// <summary>
@@ -232,5 +233,6 @@ public class WaveTrendOscillatorValue(WaveTrendOscillator indicator, DateTimeOff
 	/// <summary>
 	/// Gets the second Wavetrend line value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Wt2 => Wt2Value.ToNullableDecimal();
 }

--- a/Algo/Indicators/WoodiesCCI.cs
+++ b/Algo/Indicators/WoodiesCCI.cs
@@ -95,6 +95,7 @@ public class WoodiesCCIValue(WoodiesCCI indicator, DateTimeOffset time) : Comple
 	/// <summary>
 	/// Gets the CCI value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Cci => CciValue.ToNullableDecimal();
 
 	/// <summary>
@@ -105,5 +106,6 @@ public class WoodiesCCIValue(WoodiesCCI indicator, DateTimeOffset time) : Comple
 	/// <summary>
 	/// Gets the SMA value.
 	/// </summary>
+	[Browsable(false)]
 	public decimal? Sma => SmaValue.ToNullableDecimal();
 }


### PR DESCRIPTION
## Summary
- hide computed properties in ComplexIndicatorValue descendants by adding `[Browsable(false)]`
- fix indentation using tabs per code style

## Testing
- `dotnet build StockSharp.sln -c Release -v minimal` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68754869e6708323a586ca8633d9128c