### PR TITLE
Add README for Algo.Analytics

### DIFF
--- a/Algo.Analytics/README.md
+++ b/Algo.Analytics/README.md
@@ -1,0 +1,54 @@
+# Algo.Analytics
+
+Algo.Analytics is a small library that exposes a common set of interfaces for running analytics scripts on top of the StockSharp trading platform. The package itself does not contain any user interface but defines abstractions that allow scripts written in different languages to display their results in a uniform way.
+
+The library is a part of the main StockSharp repository and can be found in the `Algo.Analytics` folder. Example scripts that implement these interfaces are located in the sibling folders:
+
+- `Algo.Analytics.CSharp` – C# examples
+- `Algo.Analytics.FSharp` – F# examples
+- `Algo.Analytics.Python` – Python examples together with helper modules for .NET interoperability
+
+## Interfaces
+
+### `IAnalyticsScript`
+Entry point for a custom analytic. The `Run` method receives the logging interface, an `IAnalyticsPanel` for output and parameters describing the market data to analyse.
+
+### `IAnalyticsPanel`
+Represents a container where a script can place the output. It allows creating:
+
+- tables via `CreateGrid`
+- two‑dimensional charts via `CreateChart`
+- three‑dimensional charts via `CreateChart` with three generic arguments
+- heatmaps via `DrawHeatmap`
+- 3D surfaces via `Draw3D`
+
+### `IAnalyticsChart`
+A chart produced by `IAnalyticsPanel`. It exposes `Append` methods to add series of points (or bubbles in the 3D case) with the desired drawing style and color.
+
+### `IAnalyticsGrid`
+A helper interface to fill tabular data and specify sorting rules.
+
+## Example scripts
+
+The example folders contain several ready‑to‑use scripts demonstrating how to implement different analytics:
+
+- **BiggestCandleScript** – finds the candle with the largest body and volume
+- **PriceVolumeScript** – shows distribution of volume by price levels
+- **IndicatorScript** – calculates a ROC indicator and plots it on a chart
+- **Chart3DScript** and **ChartDrawScript** – demonstrate drawing 3D surfaces and custom chart series
+- **NormalizePriceScript**, **PearsonCorrelationScript**, **TimeVolumeScript**, and others
+
+Python examples include a set of helper modules under `common` that simplify working with .NET types from Python code (for example `chart_extensions.py` and `storage_extensions.py`).
+
+## Building and running
+
+To compile analytics scripts or run unit tests you need a .NET SDK that supports the target framework used in the repository (currently `net9.0`). The test project (`Tests/CompilationTests.cs`) shows how to compile scripts programmatically using `StockSharp.Algo.Compilation` and then execute them with a test implementation of `IAnalyticsPanel`.
+
+Typical steps:
+
+1. Build the solution `StockSharp.sln` with the required .NET SDK.
+2. Implement `IAnalyticsScript` in your preferred language.
+3. Compile the script using the StockSharp compiler service or your own tooling and run `script.Run` providing market data storage and an implementation of `IAnalyticsPanel`.
+
+The provided examples can be used as templates for custom analytics modules.
+


### PR DESCRIPTION
## Summary
- document Algo.Analytics and its sample scripts

## Testing
- `dotnet test StockSharp_Tests.sln -c Release` *(fails: NETSDK1045 because repo targets net9.0 and only dotnet 8 installed)*

------
https://chatgpt.com/codex/tasks/task_e_687b81e741688323a53d0bafcc810d42