### PR TITLE
Remove license sections in READMEs

### DIFF
--- a/Alerts.Interfaces/README.md
+++ b/Alerts.Interfaces/README.md
@@ -56,7 +56,4 @@ AlertServicesRegistry.ProcessingService.Register(schema);
 
 When the `IAlertProcessingService` receives an `ExecutionMessage` that satisfies the rule, the configured notification service will deliver a message to the selected channel.
 
-## License
-
-This project is distributed under the [Apache 2.0 License](../LICENSE). See the LICENSE file for more information.
 

--- a/Algo.Analytics.CSharp/README.md
+++ b/Algo.Analytics.CSharp/README.md
@@ -25,9 +25,6 @@ Each script reads candles from `IStorageRegistry` using a specified `IMarketData
 3. Load this DLL into your application or the [S# Designer](https://doc.stocksharp.com/topics/designer.html) to run individual scripts.
 4. Provide the securities, time range and storage parameters required by each script. The output will be displayed through the analytics panel implementation used (e.g., charts or tables in the Designer).
 
-## License
-
-This project is licensed under the [Apache 2.0 License](../LICENSE).
 
 ## Support
 

--- a/Algo.Analytics.FSharp/README.md
+++ b/Algo.Analytics.FSharp/README.md
@@ -54,6 +54,3 @@ Loads candles for each security and identifies the candle with the greatest rang
 2. Open `StockSharp.sln` in Visual Studio or run `dotnet build` from the repository root. The project `Algo.Analytics.FSharp` will be built as a class library.
 3. To run a script, reference it from your application or load it through the **S# Designer** analytics module, which provides an implementation of `IAnalyticsPanel` for displaying charts and tables.
 
-## License
-
-This project is released under the [Apache 2.0 License](../LICENSE).

--- a/Algo.Analytics.Python/README.md
+++ b/Algo.Analytics.Python/README.md
@@ -76,7 +76,4 @@ Analyses when the largest trading volume occurs by grouping candles by hour and 
 3. Launch StockSharp Designer or your own host application.
 4. Load any of the `.py` files and execute the script. Most scripts expect candle data to be available in your storage; adjust the date range and security identifiers as needed.
 
-## License
-
-This project is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license. See the main repository [LICENSE](../LICENSE) file for details.
 

--- a/Algo.Compilation/README.md
+++ b/Algo.Compilation/README.md
@@ -56,7 +56,4 @@ dotnet build Algo.Compilation/Algo.Compilation.csproj
 
 By default the project targets **.NET 6.0** (see `common_target_net.props`).
 
-## License
-
-This project is licensed under the same terms as the rest of StockSharp. See the root [LICENSE](../LICENSE) file for details.
 

--- a/Algo.Export/README.md
+++ b/Algo.Export/README.md
@@ -40,7 +40,4 @@ Other exporters (`ExcelExporter`, `XmlExporter`, `TextExporter`, `DatabaseExport
 
 `TemplateTxtRegistry` defines a set of default string templates which can be customized. They describe how message fields are converted to text. For instance, `TemplateTxtTick` controls how each trade is written to a text file. See the source for the full list of templates and examples.
 
-## License
-
-This project is distributed under the terms of the [StockSharp license](../../LICENSE).
 

--- a/Algo/README.md
+++ b/Algo/README.md
@@ -50,9 +50,6 @@ A full‑fledged application will include market data subscriptions, order regis
 
 Comprehensive documentation for the API and subsystems is available at the [StockSharp documentation website](https://doc.stocksharp.com/).
 
-## License
-
-StockSharp.Algo is distributed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
 
 ## Support
 

--- a/BusinessEntities/README.md
+++ b/BusinessEntities/README.md
@@ -79,5 +79,3 @@ The library is part of the `StockSharp.sln` solution and is built with:
 dotnet build StockSharp.sln
 ```
 
-## License
-Distributed under the MIT license. See `LICENSE` for details.

--- a/Charting.Interfaces/README.md
+++ b/Charting.Interfaces/README.md
@@ -30,7 +30,4 @@ The library provides only interfaces and helper types, so it can be referenced f
 
 Detailed documentation for StockSharp, including charting APIs, is available at [https://doc.stocksharp.com](https://doc.stocksharp.com).
 
-## License
-
-Charting.Interfaces is part of the StockSharp project and is distributed under the terms of the MIT license. See the repository root for the full license text.
 

--- a/Configuration/README.md
+++ b/Configuration/README.md
@@ -131,6 +131,3 @@ The assembly is titled **S#.Configuration** and described as "Configuration comp
 4. Use `InvariantCultureSerializer` when you need stable serialization irrespective of system locale.
 5. Create an instance of `InMemoryMessageAdapterProvider` to dynamically discover available message adapters.
 
-## License
-
-This project is distributed under the [Apache 2.0 License](../LICENSE).

--- a/Connectors/BitStamp/README.md
+++ b/Connectors/BitStamp/README.md
@@ -55,8 +55,4 @@ The project is part of the StockSharp solution and targets .NET. It references `
 dotnet build StockSharp.sln
 ```
 
-## License
-
-This connector is distributed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license.
-
 For more information about StockSharp connectors see the [documentation](https://doc.stocksharp.com/topics/api/connectors/crypto_exchanges/bitstamp.html).

--- a/Connectors/Bitalong/README.md
+++ b/Connectors/Bitalong/README.md
@@ -48,7 +48,4 @@ The adapter can then be registered in your `Connector` or passed directly to S# 
 - `BitalongOrderCondition.cs` – custom order condition for withdrawal operations.
 - `Native` – lightweight wrappers for the exchange REST API including request helpers and model classes.
 
-## License
-
-This connector is distributed under the **Apache 2.0** license. See the repository [LICENSE](../../LICENSE) file for details.
 

--- a/Connectors/Bitexbook/README.md
+++ b/Connectors/Bitexbook/README.md
@@ -50,6 +50,3 @@ Once connected you can subscribe to market data or register/cancel orders via th
 
 Detailed instructions for creating custom connectors and using StockSharp can be found in the [official documentation](https://doc.stocksharp.com/topics/api/connectors/crypto_exchanges/bitexbook.html).
 
-## License
-
-This project is distributed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license. See the root `LICENSE` file for details.

--- a/Connectors/Tinkoff/README.md
+++ b/Connectors/Tinkoff/README.md
@@ -54,6 +54,3 @@ Attach the adapter to a `Connector` instance or another component that works wit
 
 General StockSharp documentation is available at [doc.stocksharp.com](https://doc.stocksharp.com/). The Russian documentation page for the Tinkoff adapter is located [here](https://doc.stocksharp.ru/topics/api/connectors/russia/tinkoff.html).
 
-## License
-
-Distributed under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0). See the root `LICENSE` file for the full license text.

--- a/Diagram.Core/README.md
+++ b/Diagram.Core/README.md
@@ -40,6 +40,3 @@ cd ..
 dotnet build StockSharp.sln
 ```
 
-## License
-
-Diagram.Core is part of the StockSharp project and is distributed under the [Apache 2.0 License](../LICENSE).

--- a/Localization/README.md
+++ b/Localization/README.md
@@ -51,6 +51,3 @@ Languages can also be loaded dynamically using `AddLanguage(string langCode, Str
 
 During the build process `Localization.Generator` reads `strings.json` and emits a partial class `LocalizedStrings_Items.cs`. This file exposes constants for resource keys and cached properties for quick access. `ResetCache()` can be called when the active language changes to invalidate cached values.
 
-## License
-
-`StockSharp.Localization` is distributed under the [Apache 2.0](../LICENSE) license.

--- a/Media.Names/README.md
+++ b/Media.Names/README.md
@@ -32,6 +32,3 @@ The build will restore the `Media.Generator` project, execute the source generat
 1. Place the `.png` or `.svg` file into the [`Media/logos`](../Media/logos) directory of the repository.
 2. Build the solution. The `MediaNamesGenerator` will pick up the new file and add a corresponding constant to `MediaNames`.
 
-## License
-
-This project is distributed under the [Apache 2.0 License](../LICENSE).

--- a/Media/README.md
+++ b/Media/README.md
@@ -34,6 +34,3 @@ To use the icons in your own project:
 
 After referencing you can load any image via `MediaNames` constants as shown above.
 
-## License
-
-StockSharp is distributed under the Apache 2.0 license. All icons are provided for use with StockSharp products. Some logos may be trademarks of their respective companies.

--- a/Messages/README.md
+++ b/Messages/README.md
@@ -48,6 +48,3 @@ Such messages are passed to an adapter, which forwards them to the broker or dat
 
 Further details on messages and architecture can be found in the [StockSharp documentation](https://doc.stocksharp.com/topics/api/messages.html).
 
-## License
-
-Distributed under the [Apache 2.0 License](../LICENSE).


### PR DESCRIPTION
## Summary
- scrub license references from subfolder README files

## Testing
- `grep -ni "license" $(find . -name README.md)`

------
https://chatgpt.com/codex/tasks/task_e_687bb7ae40608323b8892ddb37145385