### PR TITLE
Implement ToString overrides for indicator values

### DIFF
--- a/Algo/Indicators/AdaptivePriceZone.cs
+++ b/Algo/Indicators/AdaptivePriceZone.cs
@@ -211,4 +211,7 @@ public class AdaptivePriceZoneValue(AdaptivePriceZone indicator, DateTimeOffset 
 	/// </summary>
 	[Browsable(false)]
 	public decimal? LowerBand => LowerBandValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"MovingAverage={MovingAverage}, UpperBand={UpperBand}, LowerBand={LowerBand}";
 }

--- a/Algo/Indicators/Alligator.cs
+++ b/Algo/Indicators/Alligator.cs
@@ -124,4 +124,7 @@ public class AlligatorValue(Alligator indicator, DateTimeOffset time) : ComplexI
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Lips => LipsValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Jaw={Jaw}, Teeth={Teeth}, Lips={Lips}";
 }

--- a/Algo/Indicators/Aroon.cs
+++ b/Algo/Indicators/Aroon.cs
@@ -298,4 +298,7 @@ public class AroonValue(Aroon indicator, DateTimeOffset time) : ComplexIndicator
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Down => DownValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Up={Up}, Down={Down}";
 }

--- a/Algo/Indicators/AverageDirectionalIndex.cs
+++ b/Algo/Indicators/AverageDirectionalIndex.cs
@@ -115,4 +115,7 @@ public class AverageDirectionalIndexValue(AverageDirectionalIndex indicator, Dat
 	/// </summary>
 	[Browsable(false)]
 	public decimal? MovingAverage => MovingAverageValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Dx={Dx}, MovingAverage={MovingAverage}";
 }

--- a/Algo/Indicators/BollingerBands.cs
+++ b/Algo/Indicators/BollingerBands.cs
@@ -173,4 +173,7 @@ public class BollingerBandsValue(BollingerBands indicator, DateTimeOffset time) 
 	/// </summary>
 	[Browsable(false)]
 	public decimal? LowBand => LowBandValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"MovingAverage={MovingAverage}, UpBand={UpBand}, LowBand={LowBand}";
 }

--- a/Algo/Indicators/ChandeKrollStop.cs
+++ b/Algo/Indicators/ChandeKrollStop.cs
@@ -199,4 +199,7 @@ public class ChandeKrollStopValue(ChandeKrollStop indicator, DateTimeOffset time
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Lowest => LowestValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Highest={Highest}, Lowest={Lowest}";
 }

--- a/Algo/Indicators/CompositeMomentum.cs
+++ b/Algo/Indicators/CompositeMomentum.cs
@@ -175,4 +175,7 @@ public class CompositeMomentumValue(CompositeMomentum indicator, DateTimeOffset 
 	/// </summary>
 	[Browsable(false)]
 	public decimal? CompositeLine => CompositeLineValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Sma={Sma}, CompositeLine={CompositeLine}";
 }

--- a/Algo/Indicators/ConnorsRSI.cs
+++ b/Algo/Indicators/ConnorsRSI.cs
@@ -282,4 +282,7 @@ public class ConnorsRSIValue(ConnorsRSI indicator, DateTimeOffset time) : Comple
 	/// </summary>
 	[Browsable(false)]
 	public decimal? CrsiLine => CrsiLineValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Rsi={Rsi}, UpDownRsi={UpDownRsi}, RocRsi={RocRsi}, CrsiLine={CrsiLine}";
 }

--- a/Algo/Indicators/ConstanceBrownCompositeIndex.cs
+++ b/Algo/Indicators/ConstanceBrownCompositeIndex.cs
@@ -193,4 +193,7 @@ public class ConstanceBrownCompositeIndexValue(ConstanceBrownCompositeIndex indi
 	/// </summary>
 	[Browsable(false)]
 	public decimal? CompositeIndexLine => CompositeIndexLineValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Rsi={Rsi}, Stoch={Stoch}, CompositeIndexLine={CompositeIndexLine}";
 }

--- a/Algo/Indicators/DirectionalIndex.cs
+++ b/Algo/Indicators/DirectionalIndex.cs
@@ -137,4 +137,7 @@ public class DirectionalIndexValue(DirectionalIndex indicator, DateTimeOffset ti
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Minus => MinusValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Plus={Plus}, Minus={Minus}";
 }

--- a/Algo/Indicators/DonchianChannels.cs
+++ b/Algo/Indicators/DonchianChannels.cs
@@ -165,4 +165,7 @@ public class DonchianChannelsValue(DonchianChannels indicator, DateTimeOffset ti
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Middle => MiddleValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"UpperBand={UpperBand}, LowerBand={LowerBand}, Middle={Middle}";
 }

--- a/Algo/Indicators/EhlersFisherTransform.cs
+++ b/Algo/Indicators/EhlersFisherTransform.cs
@@ -194,4 +194,7 @@ public class EhlersFisherTransformValue(EhlersFisherTransform indicator, DateTim
 	/// </summary>
 	[Browsable(false)]
 	public decimal? TriggerLine => TriggerLineValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"MainLine={MainLine}, TriggerLine={TriggerLine}";
 }

--- a/Algo/Indicators/Envelope.cs
+++ b/Algo/Indicators/Envelope.cs
@@ -170,4 +170,7 @@ public class EnvelopeValue(Envelope indicator, DateTimeOffset time) : ComplexInd
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Lower => LowerValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Middle={Middle}, Upper={Upper}, Lower={Lower}";
 }

--- a/Algo/Indicators/FibonacciRetracement.cs
+++ b/Algo/Indicators/FibonacciRetracement.cs
@@ -158,4 +158,7 @@ public class FibonacciRetracementValue(FibonacciRetracement indicator, DateTimeO
 	/// </summary>
 	[Browsable(false)]
 	public decimal?[] Levels => [.. LevelsValues.Select(v => v.ToNullableDecimal())];
+
+	/// <inheritdoc />
+	public override string ToString() => $"Levels=[{string.Join(", ", Levels)}]";
 }

--- a/Algo/Indicators/Fractals.cs
+++ b/Algo/Indicators/Fractals.cs
@@ -74,8 +74,11 @@ public class FractalsValue(Fractals fractals, DateTimeOffset time) : ComplexIndi
 				HasDown = true;
 		}
 
-		base.Add(indicator, value);
+	        base.Add(indicator, value);
 	}
+
+	/// <inheritdoc />
+	public override string ToString() => $"HasPattern={HasPattern}, HasUp={HasUp}, HasDown={HasDown}, Up={Up}, Down={Down}";
 }
 
 /// <summary>

--- a/Algo/Indicators/GatorOscillator.cs
+++ b/Algo/Indicators/GatorOscillator.cs
@@ -103,4 +103,7 @@ public class GatorOscillatorValue(GatorOscillator indicator, DateTimeOffset time
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Histogram2 => Histogram2Value.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Histogram1={Histogram1}, Histogram2={Histogram2}";
 }

--- a/Algo/Indicators/GuppyMultipleMovingAverage.cs
+++ b/Algo/Indicators/GuppyMultipleMovingAverage.cs
@@ -47,4 +47,7 @@ public class GuppyMultipleMovingAverageValue(GuppyMultipleMovingAverage indicato
 	/// </summary>
 	[Browsable(false)]
 	public decimal?[] Averages => [.. AveragesValues.Select(v => v.ToNullableDecimal())];
+
+	/// <inheritdoc />
+	public override string ToString() => $"Averages=[{string.Join(", ", Averages)}]";
 }

--- a/Algo/Indicators/Ichimoku.cs
+++ b/Algo/Indicators/Ichimoku.cs
@@ -163,4 +163,7 @@ public class IchimokuValue(Ichimoku indicator, DateTimeOffset time) : ComplexInd
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Chinkou => ChinkouValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Tenkan={Tenkan}, Kijun={Kijun}, SenkouA={SenkouA}, SenkouB={SenkouB}, Chinkou={Chinkou}";
 }

--- a/Algo/Indicators/KasePeakOscillator.cs
+++ b/Algo/Indicators/KasePeakOscillator.cs
@@ -211,4 +211,7 @@ public class KasePeakOscillatorValue(KasePeakOscillator indicator, DateTimeOffse
 	/// </summary>
 	[Browsable(false)]
 	public decimal? LongTerm => LongTermValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"ShortTerm={ShortTerm}, LongTerm={LongTerm}";
 }

--- a/Algo/Indicators/KeltnerChannels.cs
+++ b/Algo/Indicators/KeltnerChannels.cs
@@ -217,4 +217,7 @@ public class KeltnerChannelsValue(KeltnerChannels indicator, DateTimeOffset time
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Lower => LowerValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Middle={Middle}, Upper={Upper}, Lower={Lower}";
 }

--- a/Algo/Indicators/KlingerVolumeOscillator.cs
+++ b/Algo/Indicators/KlingerVolumeOscillator.cs
@@ -164,4 +164,7 @@ public class KlingerVolumeOscillatorValue(KlingerVolumeOscillator indicator, Dat
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Oscillator => OscillatorValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"ShortEma={ShortEma}, LongEma={LongEma}, Oscillator={Oscillator}";
 }

--- a/Algo/Indicators/KnowSureThing.cs
+++ b/Algo/Indicators/KnowSureThing.cs
@@ -147,4 +147,7 @@ public class KnowSureThingValue(KnowSureThing indicator, DateTimeOffset time) : 
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Signal => SignalValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"KstLine={KstLine}, Signal={Signal}";
 }

--- a/Algo/Indicators/LinearRegression.cs
+++ b/Algo/Indicators/LinearRegression.cs
@@ -174,4 +174,7 @@ public class LinearRegressionValue(LinearRegression indicator, DateTimeOffset ti
 	/// </summary>
 	[Browsable(false)]
 	public decimal? StandardError => StandardErrorValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"LinearReg={LinearReg}, RSquared={RSquared}, LinearRegSlope={LinearRegSlope}, StandardError={StandardError}";
 }

--- a/Algo/Indicators/MovingAverageConvergenceDivergenceHistogram.cs
+++ b/Algo/Indicators/MovingAverageConvergenceDivergenceHistogram.cs
@@ -111,4 +111,7 @@ public class MovingAverageConvergenceDivergenceHistogramValue(MovingAverageConve
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Signal => SignalValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Macd={Macd}, Signal={Signal}";
 }

--- a/Algo/Indicators/MovingAverageConvergenceDivergenceSignal.cs
+++ b/Algo/Indicators/MovingAverageConvergenceDivergenceSignal.cs
@@ -99,4 +99,7 @@ public class MovingAverageConvergenceDivergenceSignalValue(MovingAverageConverge
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Signal => SignalValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Macd={Macd}, Signal={Signal}";
 }

--- a/Algo/Indicators/MovingAverageRibbon.cs
+++ b/Algo/Indicators/MovingAverageRibbon.cs
@@ -156,4 +156,7 @@ public class MovingAverageRibbonValue(MovingAverageRibbon indicator, DateTimeOff
 	/// </summary>
 	[Browsable(false)]
 	public decimal?[] Averages => [.. AveragesValues.Select(v => v.ToNullableDecimal())];
+
+	/// <inheritdoc />
+	public override string ToString() => $"Averages=[{string.Join(", ", Averages)}]";
 }

--- a/Algo/Indicators/PercentagePriceOscillator.cs
+++ b/Algo/Indicators/PercentagePriceOscillator.cs
@@ -158,4 +158,7 @@ public class PercentagePriceOscillatorValue(PercentagePriceOscillator indicator,
 	/// </summary>
 	[Browsable(false)]
 	public decimal? LongEma => LongEmaValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"ShortEma={ShortEma}, LongEma={LongEma}";
 }

--- a/Algo/Indicators/PercentageVolumeOscillator.cs
+++ b/Algo/Indicators/PercentageVolumeOscillator.cs
@@ -163,4 +163,7 @@ public class PercentageVolumeOscillatorValue(PercentageVolumeOscillator indicato
 	/// </summary>
 	[Browsable(false)]
 	public decimal? LongEma => LongEmaValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"ShortEma={ShortEma}, LongEma={LongEma}";
 }

--- a/Algo/Indicators/PivotPoints.cs
+++ b/Algo/Indicators/PivotPoints.cs
@@ -160,4 +160,7 @@ public class PivotPointsValue(PivotPoints indicator, DateTimeOffset time) : Comp
 	/// </summary>
 	[Browsable(false)]
 	public decimal? S2 => S2Value.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"PivotPoint={PivotPoint}, R1={R1}, R2={R2}, S1={S1}, S2={S2}";
 }

--- a/Algo/Indicators/PriceChannels.cs
+++ b/Algo/Indicators/PriceChannels.cs
@@ -128,4 +128,7 @@ public class PriceChannelsValue(PriceChannels indicator, DateTimeOffset time) : 
 	/// </summary>
 	[Browsable(false)]
 	public decimal? LowerChannel => LowerChannelValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"UpperChannel={UpperChannel}, LowerChannel={LowerChannel}";
 }

--- a/Algo/Indicators/RainbowCharts.cs
+++ b/Algo/Indicators/RainbowCharts.cs
@@ -95,4 +95,7 @@ public class RainbowChartsValue(RainbowCharts indicator, DateTimeOffset time) : 
 	/// </summary>
 	[Browsable(false)]
 	public decimal?[] Averages => [.. AveragesValues.Select(v => v.ToNullableDecimal())];
+
+	/// <inheritdoc />
+	public override string ToString() => $"Averages=[{string.Join(", ", Averages)}]";
 }

--- a/Algo/Indicators/RelativeVigorIndex.cs
+++ b/Algo/Indicators/RelativeVigorIndex.cs
@@ -100,4 +100,7 @@ public class RelativeVigorIndexValue(RelativeVigorIndex indicator, DateTimeOffse
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Signal => SignalValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Average={Average}, Signal={Signal}";
 }

--- a/Algo/Indicators/SineWave.cs
+++ b/Algo/Indicators/SineWave.cs
@@ -159,4 +159,7 @@ public class SineWaveValue(SineWave indicator, DateTimeOffset time) : ComplexInd
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Lead => LeadValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Main={Main}, Lead={Lead}";
 }

--- a/Algo/Indicators/StochasticOscillator.cs
+++ b/Algo/Indicators/StochasticOscillator.cs
@@ -89,4 +89,7 @@ public class StochasticOscillatorValue(StochasticOscillator indicator, DateTimeO
 	/// </summary>
 	[Browsable(false)]
 	public decimal? D => DValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"K={K}, D={D}";
 }

--- a/Algo/Indicators/VortexIndicator.cs
+++ b/Algo/Indicators/VortexIndicator.cs
@@ -223,4 +223,7 @@ public class VortexIndicatorValue(VortexIndicator indicator, DateTimeOffset time
 	/// </summary>
 	[Browsable(false)]
 	public decimal? MinusVi => MinusViValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"PlusVi={PlusVi}, MinusVi={MinusVi}";
 }

--- a/Algo/Indicators/WaveTrendOscillator.cs
+++ b/Algo/Indicators/WaveTrendOscillator.cs
@@ -235,4 +235,7 @@ public class WaveTrendOscillatorValue(WaveTrendOscillator indicator, DateTimeOff
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Wt2 => Wt2Value.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Wt1={Wt1}, Wt2={Wt2}";
 }

--- a/Algo/Indicators/WoodiesCCI.cs
+++ b/Algo/Indicators/WoodiesCCI.cs
@@ -108,4 +108,7 @@ public class WoodiesCCIValue(WoodiesCCI indicator, DateTimeOffset time) : Comple
 	/// </summary>
 	[Browsable(false)]
 	public decimal? Sma => SmaValue.ToNullableDecimal();
+
+	/// <inheritdoc />
+	public override string ToString() => $"Cci={Cci}, Sma={Sma}";
 }


### PR DESCRIPTION
## Summary
- override `ToString` in each `IComplexIndicatorValue` implementation
- revert accidental change in `IIndicatorValue`

## Testing
- `dotnet build -c Release StockSharp.sln` *(fails: EnableWindowsTargeting/unsupported SDK)*

------
https://chatgpt.com/codex/tasks/task_e_687be12dca4483239a06d4ee333d2e59