### PR TITLE
Add GPU calculator for Oscillator of Moving Average

### DIFF
--- a/Algo.Gpu/Indicators/GpuOscillatorOfMovingAverageCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuOscillatorOfMovingAverageCalculator.cs
@@ -1,0 +1,200 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Oscillator of Moving Average calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuOscillatorOfMovingAverageParams"/> struct.
+/// </remarks>
+/// <param name="shortPeriod">Short moving average period.</param>
+/// <param name="longPeriod">Long moving average period.</param>
+/// <param name="priceType">Price type.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuOscillatorOfMovingAverageParams(int shortPeriod, int longPeriod, byte priceType) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Short moving average period.
+	/// </summary>
+	public int ShortPeriod = shortPeriod;
+
+	/// <summary>
+	/// Long moving average period.
+	/// </summary>
+	public int LongPeriod = longPeriod;
+
+	/// <summary>
+	/// Price type to extract from candles.
+	/// </summary>
+	public byte PriceType = priceType;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		Unsafe.AsRef(in this).PriceType = (byte)(indicator.Source ?? Level1Fields.ClosePrice);
+
+		if (indicator is OscillatorOfMovingAverage oma)
+		{
+			Unsafe.AsRef(in this).ShortPeriod = oma.ShortPeriod;
+			Unsafe.AsRef(in this).LongPeriod = oma.LongPeriod;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Oscillator of Moving Average (OMA).
+/// </summary>
+public class GpuOscillatorOfMovingAverageCalculator : GpuIndicatorCalculatorBase<OscillatorOfMovingAverage, GpuOscillatorOfMovingAverageParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuOscillatorOfMovingAverageParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuOscillatorOfMovingAverageCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuOscillatorOfMovingAverageCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+				<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuOscillatorOfMovingAverageParams>>(OmaParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuOscillatorOfMovingAverageParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		// Flatten input
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		// Re-split [series][param][bar]
+		var result = new GpuIndicatorResult[seriesCount][][];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: Oscillator of Moving Average computation for multiple series and multiple parameter sets. Results are stored as [param][globalIdx].
+	/// </summary>
+	private static void OmaParamsSeriesKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuOscillatorOfMovingAverageParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+
+		var candle = flatCandles[globalIdx];
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+		flatResults[resIndex] = new() { Time = candle.Time, Value = float.NaN, IsFormed = 0 };
+
+		var prm = parameters[paramIdx];
+		var shortPeriod = prm.ShortPeriod;
+		var longPeriod = prm.LongPeriod;
+
+		if (shortPeriod <= 0 || longPeriod <= 0)
+			return;
+
+		var maxPeriod = shortPeriod > longPeriod ? shortPeriod : longPeriod;
+
+		if (candleIdx < maxPeriod - 1)
+			return;
+
+		var priceType = (Level1Fields)prm.PriceType;
+		var shortSum = 0f;
+		var longSum = 0f;
+
+		for (var j = 0; j < shortPeriod; j++)
+			shortSum += ExtractPrice(flatCandles[globalIdx - j], priceType);
+
+		for (var j = 0; j < longPeriod; j++)
+			longSum += ExtractPrice(flatCandles[globalIdx - j], priceType);
+
+		var shortAvg = shortSum / shortPeriod;
+		var longAvg = longSum / longPeriod;
+
+		var value = longAvg == 0f ? 0f : (shortAvg - longAvg) / longAvg * 100f;
+		flatResults[resIndex] = new() { Time = candle.Time, Value = value, IsFormed = 1 };
+	}
+}

--- a/Algo.Gpu/README.md
+++ b/Algo.Gpu/README.md
@@ -81,10 +81,12 @@ context.Dispose();
 ### Indicators
 
 - **`GpuSmaCalculator`** – Simple Moving Average calculator supporting multiple price types and batch processing
+- **`GpuOscillatorOfMovingAverageCalculator`** – Oscillator of Moving Average GPU calculator with batched processing support
 
 ### Data Types
 
 - **`GpuSmaParams`** – parameter structure for SMA calculations with Level1Fields price type support
+- **`GpuOscillatorOfMovingAverageParams`** – parameter structure encapsulating OMA short/long periods and price type
 - **`IGpuIndicatorParams`** – interface for GPU indicator parameter structures
 - **`IGpuIndicatorResult`** – interface for GPU calculation results with ToValue() conversion method
 


### PR DESCRIPTION
## Summary
- add a GPU calculator and parameter struct for the Oscillator of Moving Average indicator, mirroring existing GPU patterns
- document the new calculator and parameters in the Algo.Gpu README

## Testing
- dotnet build Algo.Gpu/Algo.Gpu.csproj *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e265255ea08323ae61908f56dc9057