### PR TITLE
Add GPU Momentum of Moving Average calculator

### DIFF
--- a/Algo.Gpu/Indicators/GpuMomentumOfMovingAverageCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuMomentumOfMovingAverageCalculator.cs
@@ -1,0 +1,220 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Momentum of Moving Average calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuMomentumOfMovingAverageParams"/> struct.
+/// </remarks>
+/// <param name="length">Moving average length.</param>
+/// <param name="momentumPeriod">Momentum period.</param>
+/// <param name="priceType">Price type.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuMomentumOfMovingAverageParams(int length, int momentumPeriod, byte priceType) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Moving average period length.
+	/// </summary>
+	public int Length = length;
+
+	/// <summary>
+	/// Momentum lookback period.
+	/// </summary>
+	public int MomentumPeriod = momentumPeriod;
+
+	/// <summary>
+	/// Price type to extract from candles.
+	/// </summary>
+	public byte PriceType = priceType;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		Unsafe.AsRef(in this).PriceType = (byte)(indicator.Source ?? Level1Fields.ClosePrice);
+
+		if (indicator is MomentumOfMovingAverage moma)
+		{
+			Unsafe.AsRef(in this).Length = moma.Length;
+			Unsafe.AsRef(in this).MomentumPeriod = moma.MomentumPeriod;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Momentum of Moving Average (MOMA).
+/// </summary>
+public class GpuMomentumOfMovingAverageCalculator : GpuIndicatorCalculatorBase<MomentumOfMovingAverage, GpuMomentumOfMovingAverageParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuMomentumOfMovingAverageParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuMomentumOfMovingAverageCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuMomentumOfMovingAverageCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuMomentumOfMovingAverageParams>>(MomentumParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuMomentumOfMovingAverageParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		// Flatten input
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		// Re-split [series][param][bar]
+		var result = new GpuIndicatorResult[seriesCount][][];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: Momentum of Moving Average computation for multiple series and multiple parameter sets.
+	/// Results are stored as [param][globalIdx].
+	/// </summary>
+	private static void MomentumParamsSeriesKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuMomentumOfMovingAverageParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+		var candle = flatCandles[globalIdx];
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+
+		flatResults[resIndex] = new()
+		{
+			Time = candle.Time,
+			Value = float.NaN,
+			IsFormed = 0,
+		};
+
+		var prm = parameters[paramIdx];
+		var maLength = prm.Length;
+		var momPeriod = prm.MomentumPeriod;
+
+		if (maLength <= 0 || momPeriod <= 0)
+			return;
+
+		if (candleIdx + 1 < maLength)
+			return;
+
+		var priceType = (Level1Fields)prm.PriceType;
+		var sum = 0f;
+
+		for (var j = 0; j < maLength; j++)
+			sum += ExtractPrice(flatCandles[globalIdx - j], priceType);
+
+		var ma = sum / maLength;
+		var prevIdx = candleIdx - momPeriod;
+
+		if (prevIdx < maLength - 1)
+			return;
+
+		var prevGlobalIdx = offset + prevIdx;
+		sum = 0f;
+
+		for (var j = 0; j < maLength; j++)
+			sum += ExtractPrice(flatCandles[prevGlobalIdx - j], priceType);
+
+		var prevMa = sum / maLength;
+
+		if (prevMa == 0f)
+			return;
+
+		var momentum = (ma - prevMa) / prevMa * 100f;
+
+		flatResults[resIndex] = new()
+		{
+			Time = candle.Time,
+			Value = momentum,
+			IsFormed = 1,
+		};
+	}
+}


### PR DESCRIPTION
## Summary
- add GPU parameter struct for Momentum of Moving Average
- implement the Momentum of Moving Average GPU calculator and kernel to evaluate multiple series/parameter combinations

## Testing
- dotnet build Algo.Gpu/Algo.Gpu.csproj *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e264e1a55883239301e585e55817d0