### PR TITLE
Add GPU calculator for LinearReg indicator

### DIFF
--- a/Algo.Gpu/Indicators/GpuLinearRegCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuLinearRegCalculator.cs
@@ -1,0 +1,197 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Linear Regression calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuLinearRegParams"/> struct.
+/// </remarks>
+/// <param name="length">Linear Regression length.</param>
+/// <param name="priceType">Price type.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuLinearRegParams(int length, byte priceType) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Regression window length.
+	/// </summary>
+	public int Length = length;
+
+	/// <summary>
+	/// Price type to extract from candles.
+	/// </summary>
+	public byte PriceType = priceType;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		Unsafe.AsRef(in this).PriceType = (byte)(indicator.Source ?? Level1Fields.ClosePrice);
+
+		if (indicator is LinearReg linearReg)
+		{
+			Unsafe.AsRef(in this).Length = linearReg.Length;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Linear Regression indicator.
+/// </summary>
+public class GpuLinearRegCalculator : GpuIndicatorCalculatorBase<LinearReg, GpuLinearRegParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuLinearRegParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuLinearRegCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuLinearRegCalculator(Context context, Accelerator accelerator)
+	: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuLinearRegParams>>(LinearRegParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuLinearRegParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		var result = new GpuIndicatorResult[seriesCount][][];
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: Linear Regression computation for multiple series and multiple parameter sets.
+	/// </summary>
+	private static void LinearRegParamsSeriesKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuLinearRegParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+
+		var candle = flatCandles[globalIdx];
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+		var result = new GpuIndicatorResult { Time = candle.Time, Value = float.NaN, IsFormed = 0 };
+
+		var prm = parameters[paramIdx];
+		var L = prm.Length;
+		if (L <= 0)
+		{
+			flatResults[resIndex] = result;
+			return;
+		}
+
+		if (candleIdx < L - 1)
+		{
+			flatResults[resIndex] = result;
+			return;
+		}
+
+		var sumX = 0f;
+		var sumY = 0f;
+		var sumXY = 0f;
+		var sumX2 = 0f;
+		var start = globalIdx - L + 1;
+		var priceType = (Level1Fields)prm.PriceType;
+
+		for (var j = 0; j < L; j++)
+		{
+			var x = (float)j;
+			var price = ExtractPrice(flatCandles[start + j], priceType);
+			sumX += x;
+			sumY += price;
+			sumXY += x * price;
+			sumX2 += x * x;
+		}
+
+		var lengthF = (float)L;
+		var divisor = lengthF * sumX2 - sumX * sumX;
+		var slope = 0f;
+		if (divisor != 0f)
+			slope = (lengthF * sumXY - sumX * sumY) / divisor;
+
+		var intercept = (sumY - slope * sumX) / lengthF;
+		result.Value = slope * (lengthF - 1f) + intercept;
+		result.IsFormed = 1;
+
+		flatResults[resIndex] = result;
+	}
+}


### PR DESCRIPTION
## Summary
- add GPU parameter struct mirroring LinearReg configuration for GPU usage
- implement a GPU calculator and ILGPU kernel to evaluate linear regression predictions across multiple series and parameter sets

## Testing
- dotnet build Algo.Gpu/Algo.Gpu.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e264951acc8323a03bca570610699f