### PR TITLE
Add GPU Williams Accumulation/Distribution indicator calculator

### DIFF
--- a/Algo.Gpu/Indicators/GpuWilliamsAccumulationDistributionCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuWilliamsAccumulationDistributionCalculator.cs
@@ -1,0 +1,169 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Williams Accumulation/Distribution calculation.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuWilliamsAccumulationDistributionParams : IGpuIndicatorParams
+{
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+	}
+}
+
+/// <summary>
+/// GPU calculator for Williams Accumulation/Distribution indicator.
+/// </summary>
+public class GpuWilliamsAccumulationDistributionCalculator : GpuIndicatorCalculatorBase<WilliamsAccumulationDistribution, GpuWilliamsAccumulationDistributionParams, GpuIndicatorResult>
+{
+	private readonly Action<Index2D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuWilliamsAccumulationDistributionParams>> _kernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuWilliamsAccumulationDistributionCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuWilliamsAccumulationDistributionCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_kernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index2D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuWilliamsAccumulationDistributionParams>>(WilliamsAccumulationDistributionParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuWilliamsAccumulationDistributionParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		// Flatten input
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var offset = 0;
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index2D(parameters.Length, seriesCount);
+		_kernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		// Re-split [series][param][bar]
+		var result = new GpuIndicatorResult[seriesCount][][];
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: Williams Accumulation/Distribution computation for multiple series and parameter sets.
+	/// One thread handles one (parameter, series) pair and iterates candles sequentially.
+	/// </summary>
+	private static void WilliamsAccumulationDistributionParamsSeriesKernel(
+		Index2D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuWilliamsAccumulationDistributionParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+
+		var offset = offsets[seriesIdx];
+		var len = lengths[seriesIdx];
+		if (len <= 0)
+			return;
+
+		_ = parameters[paramIdx];
+
+		var hasPrevClose = false;
+		float prevClose = 0f;
+		float ad = 0f;
+
+		for (var i = 0; i < len; i++)
+		{
+			var globalIdx = offset + i;
+			var candle = flatCandles[globalIdx];
+			var resIndex = paramIdx * flatCandles.Length + globalIdx;
+			var result = new GpuIndicatorResult
+			{
+				Time = candle.Time,
+				Value = float.NaN,
+				IsFormed = 0
+			};
+
+			if (!hasPrevClose)
+			{
+				prevClose = candle.Close;
+				hasPrevClose = true;
+				flatResults[resIndex] = result;
+				continue;
+			}
+
+			float todayAd;
+			if (candle.Close > prevClose)
+				todayAd = candle.Close - MathF.Min(candle.Low, prevClose);
+			else if (candle.Close < prevClose)
+				todayAd = candle.Close - MathF.Max(candle.High, prevClose);
+			else
+				todayAd = 0f;
+
+			ad += todayAd;
+			prevClose = candle.Close;
+
+			result.Value = ad;
+			result.IsFormed = 1;
+			flatResults[resIndex] = result;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a GPU calculator for the Williams Accumulation/Distribution indicator, including parameter wrapper and sequential kernel logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27386a11883239ac52a64e7284752