### PR TITLE
Add GPU Wilder moving average calculator

### DIFF
--- a/Algo.Gpu/Indicators/GpuWilderMovingAverageCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuWilderMovingAverageCalculator.cs
@@ -1,0 +1,179 @@
+﻿namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Wilder Moving Average calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuWilderMovingAverageParams"/> struct.
+/// </remarks>
+/// <param name="length">Wilder MA length.</param>
+/// <param name="priceType">Price type.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuWilderMovingAverageParams(int length, byte priceType) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Wilder MA period length.
+	/// </summary>
+	public int Length = length;
+
+	/// <summary>
+	/// Price type to extract from candles.
+	/// </summary>
+	public byte PriceType = priceType;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		Unsafe.AsRef(in this).PriceType = (byte)(indicator.Source ?? Level1Fields.ClosePrice);
+
+		if (indicator is WilderMovingAverage wilder)
+		{
+			Unsafe.AsRef(in this).Length = wilder.Length;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Welles Wilder Moving Average.
+/// </summary>
+public class GpuWilderMovingAverageCalculator : GpuIndicatorCalculatorBase<WilderMovingAverage, GpuWilderMovingAverageParams, GpuIndicatorResult>
+{
+	private readonly Action<Index2D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuWilderMovingAverageParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuWilderMovingAverageCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuWilderMovingAverageCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index2D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuWilderMovingAverageParams>>(WilderParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuWilderMovingAverageParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var offset = 0;
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index2D(parameters.Length, seriesCount);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		var result = new GpuIndicatorResult[seriesCount][][];
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			var seriesOffset = seriesOffsets[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffset + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: Wilder Moving Average computation for multiple series and parameter sets.
+	/// </summary>
+	private static void WilderParamsSeriesKernel(
+		Index2D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuWilderMovingAverageParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+
+		var len = lengths[seriesIdx];
+		if (len <= 0)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var prm = parameters[paramIdx];
+		var length = prm.Length;
+		if (length <= 0)
+			length = 1;
+
+		var priceType = (Level1Fields)prm.PriceType;
+		var totalCandles = flatCandles.Length;
+		var baseIndex = paramIdx * totalCandles;
+
+		float prevValue = 0f;
+
+		for (var i = 0; i < len; i++)
+		{
+			var globalIdx = offset + i;
+			var candle = flatCandles[globalIdx];
+			var price = ExtractPrice(candle, priceType);
+
+			var count = i + 1;
+			if (count > length)
+				count = length;
+
+			var value = (prevValue * (count - 1) + price) / count;
+			prevValue = value;
+
+			var resIndex = baseIndex + globalIdx;
+			flatResults[resIndex] = new()
+			{
+				Time = candle.Time,
+				Value = value,
+				IsFormed = (byte)(i >= length - 1 ? 1 : 0),
+			};
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a GPU parameter struct for the Wilder moving average indicator
- implement a GPU calculator and ILGPU kernel to evaluate Wilder MA across multiple series and parameter sets

## Testing
- dotnet build Algo.Gpu/Algo.Gpu.csproj *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2737e99b08323b3a6a12ea5bf0a62