### PR TITLE
Add GPU calculator for VWAP indicator

### DIFF
--- a/Algo.Gpu/Indicators/GpuVolumeWeightedAveragePriceCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuVolumeWeightedAveragePriceCalculator.cs
@@ -1,0 +1,161 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Volume Weighted Average Price (VWAP) calculation.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuVwapParams : IGpuIndicatorParams
+{
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+	}
+}
+
+/// <summary>
+/// GPU calculator for Volume Weighted Average Price (VWAP).
+/// </summary>
+public class GpuVolumeWeightedAveragePriceCalculator : GpuIndicatorCalculatorBase<VolumeWeightedAveragePrice, GpuVwapParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuVwapParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuVolumeWeightedAveragePriceCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuVolumeWeightedAveragePriceCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuVwapParams>>(VwapParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuVwapParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+		var result = new GpuIndicatorResult[seriesCount][][];
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel for VWAP computation over multiple series and parameter sets.
+	/// </summary>
+	private static void VwapParamsSeriesKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuVwapParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+		var candle = flatCandles[globalIdx];
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+
+		var cumulativeVolume = 0f;
+		var cumulativePriceVolume = 0f;
+		for (var i = 0; i <= candleIdx; i++)
+		{
+			var current = flatCandles[offset + i];
+			var typicalPrice = (current.High + current.Low + current.Close) / 3f;
+			var volume = current.Volume;
+
+			cumulativeVolume += volume;
+			cumulativePriceVolume += typicalPrice * volume;
+		}
+
+		if (cumulativeVolume > 0f)
+		{
+			flatResults[resIndex] = new()
+			{
+				Time = candle.Time,
+				Value = cumulativePriceVolume / cumulativeVolume,
+				IsFormed = 1,
+			};
+		}
+		else
+		{
+			flatResults[resIndex] = new()
+			{
+				Time = candle.Time,
+				Value = float.NaN,
+				IsFormed = 0,
+			};
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a GPU parameter struct and calculator for the Volume Weighted Average Price indicator
- implement the ILGPU kernel and host-side orchestration to support multi-series VWAP computation

## Testing
- dotnet build Algo.Gpu/Algo.Gpu.csproj *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27357a79083239fbe42478dee6b32