### PR TITLE
Add GPU Typical Price calculator

### DIFF
--- a/Algo.Gpu/Indicators/GpuTypicalPriceCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuTypicalPriceCalculator.cs
@@ -1,0 +1,155 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Typical Price calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuTypicalPriceParams"/> struct.
+/// </remarks>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuTypicalPriceParams : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Typical Price indicator does not require parameters.
+	/// </summary>
+	public void FromIndicator(IIndicator indicator)
+	{
+	}
+}
+
+/// <summary>
+/// GPU calculator for Typical Price indicator.
+/// </summary>
+public class GpuTypicalPriceCalculator : GpuIndicatorCalculatorBase<TypicalPrice, GpuTypicalPriceParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuTypicalPriceParams>> _kernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuTypicalPriceCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuTypicalPriceCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_kernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuTypicalPriceParams>>(TypicalPriceKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuTypicalPriceParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_kernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		var result = new GpuIndicatorResult[seriesCount][][];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			var seriesResult = new GpuIndicatorResult[parameters.Length][];
+
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+
+				seriesResult[p] = arr;
+			}
+
+			result[s] = seriesResult;
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel that calculates Typical Price for all series, parameters and bars.
+	/// </summary>
+	private static void TypicalPriceKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuTypicalPriceParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+		var candle = flatCandles[globalIdx];
+		var value = (candle.High + candle.Low + candle.Close) / 3f;
+
+		flatResults[resIndex] = new()
+		{
+			Time = candle.Time,
+			Value = value,
+			IsFormed = 1,
+		};
+	}
+}


### PR DESCRIPTION
## Summary
- add a GPU calculator for the Typical Price indicator, mirroring the CPU logic on flattened candle input
- introduce a GPU parameter struct for Typical Price with XML documentation and tab-based formatting

## Testing
- dotnet build Algo.Gpu/Algo.Gpu.csproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2733d248c8323b3afee5fe9b429bc