### PR TITLE
Add GPU standard deviation calculator

### DIFF
--- a/Algo.Gpu/Indicators/GpuStandardDeviationCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuStandardDeviationCalculator.cs
@@ -1,0 +1,184 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Standard Deviation calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuStandardDeviationParams"/> struct.
+/// </remarks>
+/// <param name="length">Standard Deviation length.</param>
+/// <param name="priceType">Price type.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuStandardDeviationParams(int length, byte priceType) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Standard Deviation window length.
+	/// </summary>
+	public int Length = length;
+
+	/// <summary>
+	/// Price type to extract from candles.
+	/// </summary>
+	public byte PriceType = priceType;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		Unsafe.AsRef(in this).PriceType = (byte)(indicator.Source ?? Level1Fields.ClosePrice);
+
+		if (indicator is StandardDeviation std)
+		{
+			Unsafe.AsRef(in this).Length = std.Length;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Standard Deviation indicator.
+/// </summary>
+public class GpuStandardDeviationCalculator : GpuIndicatorCalculatorBase<StandardDeviation, GpuStandardDeviationParams, GpuIndicatorResult>
+{
+	private readonly Action<Index2D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuStandardDeviationParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuStandardDeviationCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuStandardDeviationCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index2D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuStandardDeviationParams>>(StandardDeviationParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuStandardDeviationParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var offset = 0;
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index2D(parameters.Length, seriesCount);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		var result = new GpuIndicatorResult[seriesCount][][];
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel that calculates Standard Deviation for multiple series and parameter sets.
+	/// </summary>
+	private static void StandardDeviationParamsSeriesKernel(
+		Index2D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuStandardDeviationParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+
+		var len = lengths[seriesIdx];
+		if (len <= 0)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var prm = parameters[paramIdx];
+		var length = prm.Length;
+		if (length <= 0)
+			length = 1;
+
+		var priceType = (Level1Fields)prm.PriceType;
+
+		float sum = 0f;
+		float sumSq = 0f;
+
+		for (var i = 0; i < len; i++)
+		{
+			var globalIdx = offset + i;
+			var candle = flatCandles[globalIdx];
+			var price = ExtractPrice(candle, priceType);
+
+			var resIndex = paramIdx * flatCandles.Length + globalIdx;
+			flatResults[resIndex] = new() { Time = candle.Time, Value = float.NaN, IsFormed = 0 };
+
+			sum += price;
+			sumSq += price * price;
+
+			if (i >= length)
+			{
+				var prevPrice = ExtractPrice(flatCandles[globalIdx - length], priceType);
+				sum -= prevPrice;
+				sumSq -= prevPrice * prevPrice;
+			}
+
+			if (i >= length - 1)
+			{
+				var mean = sum / length;
+				var variance = (sumSq / length) - (mean * mean);
+				variance = MathF.Max(variance, 0f);
+
+				flatResults[resIndex] = new() { Time = candle.Time, Value = MathF.Sqrt(variance), IsFormed = 1 };
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a GPU parameter struct and calculator for the StandardDeviation indicator
- implement an ILGPU kernel that computes the rolling standard deviation across series and parameter sets

## Testing
- not run (dotnet CLI is not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e272f808848323931a8987a53611ef