### PR TITLE
Add GPU Rank Correlation Index calculator

### DIFF
--- a/Algo.Gpu/Indicators/GpuRankCorrelationIndexCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuRankCorrelationIndexCalculator.cs
@@ -1,0 +1,215 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Rank Correlation Index (RCI) calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuRankCorrelationIndexParams"/> struct.
+/// </remarks>
+/// <param name="length">RCI window length.</param>
+/// <param name="priceType">Price type to extract from candles.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuRankCorrelationIndexParams(int length, byte priceType) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// RCI window length.
+	/// </summary>
+	public int Length = length;
+
+	/// <summary>
+	/// Price type to extract from candles.
+	/// </summary>
+	public byte PriceType = priceType;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		Unsafe.AsRef(in this).PriceType = (byte)(indicator.Source ?? Level1Fields.ClosePrice);
+
+		if (indicator is RankCorrelationIndex rci)
+		{
+			Unsafe.AsRef(in this).Length = rci.Length;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Rank Correlation Index (RCI).
+/// </summary>
+public class GpuRankCorrelationIndexCalculator : GpuIndicatorCalculatorBase<RankCorrelationIndex, GpuRankCorrelationIndexParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuRankCorrelationIndexParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuRankCorrelationIndexCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuRankCorrelationIndexCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuRankCorrelationIndexParams>>(RciParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuRankCorrelationIndexParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		// Flatten input series to contiguous buffers for GPU processing.
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		// Restore [series][parameter][bar] shape.
+		var result = new GpuIndicatorResult[seriesCount][][];
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: RCI computation for multiple series and parameter sets. Results stored as [parameter][global index].
+	/// </summary>
+	private static void RciParamsSeriesKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuRankCorrelationIndexParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+		var candle = flatCandles[globalIdx];
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+		flatResults[resIndex] = new() { Time = candle.Time, Value = float.NaN, IsFormed = 0 };
+
+		var prm = parameters[paramIdx];
+		var L = prm.Length;
+		if (L <= 1 || candleIdx < L - 1)
+			return;
+
+		var priceType = (Level1Fields)prm.PriceType;
+		var startIdx = globalIdx - (L - 1);
+
+		double meanValue = 0d;
+		double meanTime = 0d;
+		double cov = 0d;
+		double varValue = 0d;
+		double varTime = 0d;
+
+		for (var i = 0; i < L; i++)
+		{
+			var currentIdx = startIdx + i;
+			var value = ExtractPrice(flatCandles[currentIdx], priceType);
+
+			var less = 0;
+			var equal = 0;
+			for (var j = 0; j < L; j++)
+			{
+				var compare = ExtractPrice(flatCandles[startIdx + j], priceType);
+				if (compare < value)
+				{
+					less++;
+				}
+				else if (compare == value)
+				{
+					equal++;
+				}
+			}
+
+			var rankValue = less + ((equal + 1) * 0.5f);
+			var rankTime = i + 1;
+
+			var count = i + 1;
+			var dx = rankValue - meanValue;
+			meanValue += dx / count;
+			var dy = rankTime - meanTime;
+			meanTime += dy / count;
+			cov += dx * (rankTime - meanTime);
+			varValue += dx * (rankValue - meanValue);
+			varTime += dy * (rankTime - meanTime);
+		}
+
+		var denom = Math.Sqrt(varValue * varTime);
+		if (denom <= double.Epsilon)
+			return;
+
+		var correlation = cov / denom;
+		flatResults[resIndex] = new()
+		{
+			Time = candle.Time,
+			Value = (float)correlation,
+			IsFormed = 1
+		};
+	}
+}


### PR DESCRIPTION
## Summary
- add GPU parameter struct and calculator for the Rank Correlation Index indicator
- implement ILGPU kernel that computes Spearman rank correlation over rolling candle windows

## Testing
- `dotnet build Algo.Gpu/Algo.Gpu.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e272b963b883239bb6c9c77f403756