### PR TITLE
Add GPU Intraday Intensity Index calculator

### DIFF
--- a/Algo.Gpu/Indicators/GpuIntradayIntensityIndexCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuIntradayIntensityIndexCalculator.cs
@@ -1,0 +1,176 @@
+﻿namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Intraday Intensity Index calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuIntradayIntensityIndexParams"/> struct.
+/// </remarks>
+/// <param name="length">Moving average length.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuIntradayIntensityIndexParams(int length) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Moving average window length.
+	/// </summary>
+	public int Length = length;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		if (indicator is IntradayIntensityIndex iii)
+		{
+			Unsafe.AsRef(in this).Length = iii.Length;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Intraday Intensity Index indicator.
+/// </summary>
+public class GpuIntradayIntensityIndexCalculator : GpuIndicatorCalculatorBase<IntradayIntensityIndex, GpuIntradayIntensityIndexParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuIntradayIntensityIndexParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuIntradayIntensityIndexCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuIntradayIntensityIndexCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuIntradayIntensityIndexParams>>(IntradayIntensityIndexParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuIntradayIntensityIndexParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		// Flatten input
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		// Re-split [series][param][bar]
+		var result = new GpuIndicatorResult[seriesCount][][];
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: Intraday Intensity Index computation for multiple series and parameter sets.
+	/// Each thread processes single candle index for specific (series, parameter) pair.
+	/// </summary>
+	private static void IntradayIntensityIndexParamsSeriesKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuIntradayIntensityIndexParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+
+		var candle = flatCandles[globalIdx];
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+		flatResults[resIndex] = new() { Time = candle.Time, Value = float.NaN, IsFormed = 0 };
+
+		var prm = parameters[paramIdx];
+		var L = prm.Length;
+		if (L <= 0)
+			L = 1;
+
+		if (candleIdx < L - 1)
+			return;
+
+		float sum = 0f;
+		for (var j = 0; j < L; j++)
+		{
+			var c = flatCandles[globalIdx - j];
+			var range = c.High - c.Low;
+			var den = range * c.Volume;
+			var iii = 0f;
+			if (den != 0f)
+			{
+				var numerator = 2f * ((c.Close - c.Low) - (c.High - c.Close));
+				iii = numerator / den;
+			}
+
+			sum += iii;
+		}
+
+		flatResults[resIndex] = new() { Time = candle.Time, Value = sum / L, IsFormed = 1 };
+	}
+}


### PR DESCRIPTION
## Summary
- add a GPU parameter struct for configuring Intraday Intensity Index calculations
- implement the GPU Intraday Intensity Index calculator and kernel to process multiple series

## Testing
- dotnet build Algo.Gpu/Algo.Gpu.csproj *(fails: `dotnet` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2645d82308323941c8a95f9950186