### PR TITLE
Add GPU calculator for Relative Momentum Index

### DIFF
--- a/Algo.Gpu/Indicators/GpuRelativeMomentumIndexCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuRelativeMomentumIndexCalculator.cs
@@ -1,0 +1,207 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Relative Momentum Index calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuRelativeMomentumIndexParams"/> struct.
+/// </remarks>
+/// <param name="length">SMA length applied to momentum values.</param>
+/// <param name="momentumPeriod">Momentum period.</param>
+/// <param name="priceType">Price type to extract.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuRelativeMomentumIndexParams(int length, int momentumPeriod, byte priceType) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Length of the smoothing SMA.
+	/// </summary>
+	public int Length = length;
+
+	/// <summary>
+	/// Momentum period.
+	/// </summary>
+	public int MomentumPeriod = momentumPeriod;
+
+	/// <summary>
+	/// Price type to extract from candles.
+	/// </summary>
+	public byte PriceType = priceType;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		Unsafe.AsRef(in this).PriceType = (byte)(indicator.Source ?? Level1Fields.ClosePrice);
+
+		if (indicator is RelativeMomentumIndex rmi)
+			{
+			Unsafe.AsRef(in this).Length = rmi.Length;
+			Unsafe.AsRef(in this).MomentumPeriod = rmi.MomentumPeriod;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Relative Momentum Index (RMI).
+/// </summary>
+public class GpuRelativeMomentumIndexCalculator : GpuIndicatorCalculatorBase<RelativeMomentumIndex, GpuRelativeMomentumIndexParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuRelativeMomentumIndexParams>> _kernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuRelativeMomentumIndexCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuRelativeMomentumIndexCalculator(Context context, Accelerator accelerator)
+	: base(context, accelerator)
+	{
+		_kernel = Accelerator.LoadAutoGroupedStreamKernel
+		<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuRelativeMomentumIndexParams>>(RelativeMomentumIndexParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuRelativeMomentumIndexParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		// Flatten input
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+		var maxLen = 0;
+
+		for (var s = 0; s < seriesCount; s++)
+			{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+
+			if (len > maxLen)
+				maxLen = len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var offset = 0;
+		for (var s = 0; s < seriesCount; s++)
+			{
+			var len = seriesLengths[s];
+			if (len > 0)
+				{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_kernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		// Re-split [series][param][bar]
+		var result = new GpuIndicatorResult[seriesCount][][];
+		for (var s = 0; s < seriesCount; s++)
+			{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+			for (var p = 0; p < parameters.Length; p++)
+				{
+				var arr = new GpuIndicatorResult[len];
+				for (var i = 0; i < len; i++)
+					{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: RMI computation for multiple series and parameter sets.
+	/// </summary>
+	private static void RelativeMomentumIndexParamsSeriesKernel(
+	Index3D index,
+	ArrayView<GpuCandle> flatCandles,
+	ArrayView<GpuIndicatorResult> flatResults,
+	ArrayView<int> offsets,
+	ArrayView<int> lengths,
+	ArrayView<GpuRelativeMomentumIndexParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+
+		var candle = flatCandles[globalIdx];
+		var result = new GpuIndicatorResult
+		{
+			Time = candle.Time,
+			Value = float.NaN,
+			IsFormed = 0
+		};
+
+		var prm = parameters[paramIdx];
+		var length = prm.Length <= 0 ? 1 : prm.Length;
+		var momentum = prm.MomentumPeriod <= 0 ? 1 : prm.MomentumPeriod;
+		var requiredIndex = momentum + length - 1;
+
+		if (candleIdx >= requiredIndex)
+			{
+			var priceType = (Level1Fields)prm.PriceType;
+			float upSum = 0f;
+			float downSum = 0f;
+
+			for (var j = 0; j < length; j++)
+				{
+				var idx = candleIdx - j;
+				var current = ExtractPrice(flatCandles[offset + idx], priceType);
+				var previous = ExtractPrice(flatCandles[offset + idx - momentum], priceType);
+
+				var up = current - previous;
+				var down = previous - current;
+
+				if (up > 0f)
+					upSum += up;
+
+				if (down > 0f)
+					downSum += down;
+			}
+
+			var den = upSum + downSum;
+
+			result.IsFormed = 1;
+
+			if (den > 0f)
+				result.Value = 100f * upSum / den;
+		}
+
+		flatResults[resIndex] = result;
+	}
+}


### PR DESCRIPTION
## Summary
- add GPU parameter struct for the Relative Momentum Index and map indicator settings
- implement the GPU calculator and ILGPU kernel for computing RMI across series and parameter sets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e272c3d1a8832397774e8fd6f8faa6