### PR TITLE
Add GPU calculator for Range Action Verification Index

### DIFF
--- a/Algo.Gpu/Indicators/GpuRangeActionVerificationIndexCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuRangeActionVerificationIndexCalculator.cs
@@ -1,0 +1,207 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Range Action Verification Index calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuRangeActionVerificationIndexParams"/> struct.
+/// </remarks>
+/// <param name="shortLength">Short SMA length.</param>
+/// <param name="longLength">Long SMA length.</param>
+/// <param name="priceType">Price type.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuRangeActionVerificationIndexParams(int shortLength, int longLength, byte priceType) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Short SMA window length.
+	/// </summary>
+	public int ShortLength = shortLength;
+
+	/// <summary>
+	/// Long SMA window length.
+	/// </summary>
+	public int LongLength = longLength;
+
+	/// <summary>
+	/// Price type to extract from candles.
+	/// </summary>
+	public byte PriceType = priceType;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		Unsafe.AsRef(in this).PriceType = (byte)(indicator.Source ?? Level1Fields.ClosePrice);
+
+		if (indicator is RangeActionVerificationIndex ravi)
+		{
+			Unsafe.AsRef(in this).ShortLength = ravi.ShortSma.Length;
+			Unsafe.AsRef(in this).LongLength = ravi.LongSma.Length;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Range Action Verification Index (RAVI).
+/// </summary>
+public class GpuRangeActionVerificationIndexCalculator : GpuIndicatorCalculatorBase<RangeActionVerificationIndex, GpuRangeActionVerificationIndexParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuRangeActionVerificationIndexParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuRangeActionVerificationIndexCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuRangeActionVerificationIndexCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuRangeActionVerificationIndexParams>>(RaviParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuRangeActionVerificationIndexParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		// Flatten input
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		// Re-split [series][param][bar]
+		var result = new GpuIndicatorResult[seriesCount][][];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: RAVI computation for multiple series and parameter sets.
+	/// </summary>
+	private static void RaviParamsSeriesKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuRangeActionVerificationIndexParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+		var candle = flatCandles[globalIdx];
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+		flatResults[resIndex] = new() { Time = candle.Time, Value = float.NaN, IsFormed = 0 };
+
+		var prm = parameters[paramIdx];
+		var shortLength = prm.ShortLength;
+		var longLength = prm.LongLength;
+
+		if (shortLength <= 0 || longLength <= 0)
+			return;
+
+		if (candleIdx + 1 < longLength || candleIdx + 1 < shortLength)
+			return;
+
+		var priceType = (Level1Fields)prm.PriceType;
+		var shortSum = 0f;
+		for (var j = 0; j < shortLength; j++)
+			shortSum += ExtractPrice(flatCandles[globalIdx - j], priceType);
+
+		var longSum = 0f;
+		for (var j = 0; j < longLength; j++)
+			longSum += ExtractPrice(flatCandles[globalIdx - j], priceType);
+
+		var longAvg = longSum / longLength;
+		if (longAvg == 0f)
+		{
+			flatResults[resIndex] = new() { Time = candle.Time, Value = 0f, IsFormed = 1 };
+			return;
+		}
+
+		var shortAvg = shortSum / shortLength;
+		var diff = shortAvg - longAvg;
+		if (diff < 0f)
+			diff = -diff;
+
+		var denom = longAvg;
+		if (denom < 0f)
+			denom = -denom;
+
+		var ravi = 100f * diff / denom;
+		flatResults[resIndex] = new() { Time = candle.Time, Value = ravi, IsFormed = 1 };
+	}
+}


### PR DESCRIPTION
## Summary
- add GPU parameters struct for the Range Action Verification Index indicator
- implement the GPU calculator and ILGPU kernel to compute RAVI values across series

## Testing
- not run (dotnet CLI is unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68e272b3f6048323b11f17cacfd19f10