### PR TITLE
Add GPU calculator for Balance of Market Power indicator

### DIFF
--- a/Algo.Gpu/Indicators/GpuBalanceOfMarketPowerCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuBalanceOfMarketPowerCalculator.cs
@@ -1,0 +1,183 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Balance of Market Power calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuBalanceOfMarketPowerParams"/> struct.
+/// </remarks>
+/// <param name="length">Smoothing length.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuBalanceOfMarketPowerParams(int length) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Balance of Market Power smoothing length.
+	/// </summary>
+	public int Length = length;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		if (indicator is BalanceOfMarketPower bmp)
+		{
+			Unsafe.AsRef(in this).Length = bmp.Length;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Balance of Market Power (BMP).
+/// </summary>
+public class GpuBalanceOfMarketPowerCalculator : GpuIndicatorCalculatorBase<BalanceOfMarketPower, GpuBalanceOfMarketPowerParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuBalanceOfMarketPowerParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuBalanceOfMarketPowerCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuBalanceOfMarketPowerCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuBalanceOfMarketPowerParams>>(BalanceOfMarketPowerParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuBalanceOfMarketPowerParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		// Flatten input
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		// Re-split [series][param][bar]
+		var result = new GpuIndicatorResult[seriesCount][][];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel computing Balance of Market Power values and smoothing them for multiple series and parameter sets.
+	/// </summary>
+	private static void BalanceOfMarketPowerParamsSeriesKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuBalanceOfMarketPowerParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+		var candle = flatCandles[globalIdx];
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+
+		flatResults[resIndex] = new() { Time = candle.Time, Value = float.NaN, IsFormed = 0 };
+
+		var prm = parameters[paramIdx];
+		var window = prm.Length;
+
+		if (window <= 0 || candleIdx < window - 1)
+			return;
+
+		var sum = 0f;
+
+		for (var j = 0; j < window; j++)
+		{
+			var sourceCandle = flatCandles[globalIdx - j];
+
+			if (sourceCandle.Volume == 0f)
+				continue;
+
+			var range = sourceCandle.High - sourceCandle.Low;
+			var denom = range == 0f ? 0.01f : range;
+			var value = (sourceCandle.Close - sourceCandle.Open) / denom;
+			sum += value;
+		}
+
+		flatResults[resIndex] = new()
+		{
+			Time = candle.Time,
+			Value = sum / window,
+			IsFormed = 1
+		};
+	}
+}


### PR DESCRIPTION
## Summary
- add GPU calculator for the Balance of Market Power indicator with ILGPU kernel and parameter struct

## Testing
- dotnet build Algo.Gpu/Algo.Gpu.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e256466ad48323b53afeb08f90091a