### PR TITLE
Add GPU calculator for Aroon Oscillator

### DIFF
--- a/Algo.Gpu/Indicators/GpuAroonOscillatorCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuAroonOscillatorCalculator.cs
@@ -1,0 +1,188 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Aroon Oscillator calculation.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="GpuAroonOscillatorParams"/> struct.
+/// </remarks>
+/// <param name="length">Aroon Oscillator period length.</param>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuAroonOscillatorParams(int length) : IGpuIndicatorParams
+{
+	/// <summary>
+	/// Period length for Aroon Oscillator.
+	/// </summary>
+	public int Length = length;
+
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+		if (indicator is AroonOscillator aroonOscillator)
+		{
+			Unsafe.AsRef(in this).Length = aroonOscillator.Length;
+		}
+	}
+}
+
+/// <summary>
+/// GPU calculator for Aroon Oscillator indicator.
+/// </summary>
+public class GpuAroonOscillatorCalculator : GpuIndicatorCalculatorBase<AroonOscillator, GpuAroonOscillatorParams, GpuIndicatorResult>
+{
+	private readonly Action<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuAroonOscillatorParams>> _kernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuAroonOscillatorCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuAroonOscillatorCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_kernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index3D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuAroonOscillatorParams>>(AroonOscillatorParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuAroonOscillatorParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		// Flatten input
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var maxLen = 0;
+		var offset = 0;
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			if (len > 0)
+			{
+				Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+				offset += len;
+				if (len > maxLen)
+					maxLen = len;
+			}
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index3D(parameters.Length, seriesCount, maxLen);
+		_kernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		// Re-split [series][param][bar]
+		var result = new GpuIndicatorResult[seriesCount][][];
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: Aroon Oscillator computation for multiple series and parameter sets.
+	/// Results are stored as [param][globalIdx].
+	/// </summary>
+	private static void AroonOscillatorParamsSeriesKernel(
+		Index3D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuAroonOscillatorParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		var candleIdx = index.Z;
+
+		var len = lengths[seriesIdx];
+		if (candleIdx >= len)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var globalIdx = offset + candleIdx;
+
+		var candle = flatCandles[globalIdx];
+		var resIndex = paramIdx * flatCandles.Length + globalIdx;
+		flatResults[resIndex] = new() { Time = candle.Time, Value = float.NaN, IsFormed = 0 };
+
+		var prm = parameters[paramIdx];
+		var period = prm.Length;
+		if (period <= 0)
+			return;
+
+		if (candleIdx + 1 < period)
+			return;
+
+		var highest = float.NegativeInfinity;
+		var highestAge = 0;
+		var lowest = float.PositiveInfinity;
+		var lowestAge = 0;
+
+		for (var j = 0; j < period; j++)
+		{
+			var idx = globalIdx - j;
+			if (idx < offset)
+				break;
+
+			var c = flatCandles[idx];
+
+			if (c.High >= highest)
+			{
+				highest = c.High;
+				highestAge = j;
+			}
+
+			if (c.Low <= lowest)
+			{
+				lowest = c.Low;
+				lowestAge = j;
+			}
+		}
+
+		var up = 100f * (period - highestAge) / period;
+		var down = 100f * (period - lowestAge) / period;
+		flatResults[resIndex] = new() { Time = candle.Time, Value = up - down, IsFormed = 1 };
+	}
+}


### PR DESCRIPTION
## Summary
- add GPU parameter struct and calculator to compute the Aroon Oscillator across series and parameter sets
- implement the ILGPU kernel mirroring the CPU indicator logic and document the new types

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e25635709483238d2776b951de38cb