### PR TITLE
Add GPU Accumulation/Distribution Line calculator

### DIFF
--- a/Algo.Gpu/Indicators/GpuAdlCalculator.cs
+++ b/Algo.Gpu/Indicators/GpuAdlCalculator.cs
@@ -1,0 +1,156 @@
+namespace StockSharp.Algo.Gpu.Indicators;
+
+/// <summary>
+/// Parameter set for GPU Accumulation/Distribution Line calculation.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct GpuAdlParams : IGpuIndicatorParams
+{
+	/// <inheritdoc />
+	public readonly void FromIndicator(IIndicator indicator)
+	{
+	}
+}
+
+/// <summary>
+/// GPU calculator for Accumulation/Distribution Line (ADL).
+/// </summary>
+public class GpuAdlCalculator : GpuIndicatorCalculatorBase<AccumulationDistributionLine, GpuAdlParams, GpuIndicatorResult>
+{
+	private readonly Action<Index2D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuAdlParams>> _paramsSeriesKernel;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GpuAdlCalculator"/> class.
+	/// </summary>
+	/// <param name="context">ILGPU context.</param>
+	/// <param name="accelerator">ILGPU accelerator.</param>
+	public GpuAdlCalculator(Context context, Accelerator accelerator)
+		: base(context, accelerator)
+	{
+		_paramsSeriesKernel = Accelerator.LoadAutoGroupedStreamKernel
+			<Index2D, ArrayView<GpuCandle>, ArrayView<GpuIndicatorResult>, ArrayView<int>, ArrayView<int>, ArrayView<GpuAdlParams>>(AdlParamsSeriesKernel);
+	}
+
+	/// <inheritdoc />
+	public override GpuIndicatorResult[][][] Calculate(GpuCandle[][] candlesSeries, GpuAdlParams[] parameters)
+	{
+		ArgumentNullException.ThrowIfNull(candlesSeries);
+		ArgumentNullException.ThrowIfNull(parameters);
+
+		if (candlesSeries.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(candlesSeries));
+
+		if (parameters.Length == 0)
+			throw new ArgumentOutOfRangeException(nameof(parameters));
+
+		var seriesCount = candlesSeries.Length;
+
+		var totalSize = 0;
+		var seriesOffsets = new int[seriesCount];
+		var seriesLengths = new int[seriesCount];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			seriesOffsets[s] = totalSize;
+			var len = candlesSeries[s]?.Length ?? 0;
+			seriesLengths[s] = len;
+			totalSize += len;
+		}
+
+		var flatCandles = new GpuCandle[totalSize];
+		var offset = 0;
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+
+			if (len == 0)
+				continue;
+
+			Array.Copy(candlesSeries[s], 0, flatCandles, offset, len);
+			offset += len;
+		}
+
+		using var inputBuffer = Accelerator.Allocate1D(flatCandles);
+		using var offsetsBuffer = Accelerator.Allocate1D(seriesOffsets);
+		using var lengthsBuffer = Accelerator.Allocate1D(seriesLengths);
+		using var paramsBuffer = Accelerator.Allocate1D(parameters);
+		using var outputBuffer = Accelerator.Allocate1D<GpuIndicatorResult>(totalSize * parameters.Length);
+
+		var extent = new Index2D(parameters.Length, seriesCount);
+		_paramsSeriesKernel(extent, inputBuffer.View, outputBuffer.View, offsetsBuffer.View, lengthsBuffer.View, paramsBuffer.View);
+		Accelerator.Synchronize();
+
+		var flatResults = outputBuffer.GetAsArray1D();
+
+		var result = new GpuIndicatorResult[seriesCount][][];
+
+		for (var s = 0; s < seriesCount; s++)
+		{
+			var len = seriesLengths[s];
+			result[s] = new GpuIndicatorResult[parameters.Length][];
+
+			for (var p = 0; p < parameters.Length; p++)
+			{
+				var arr = new GpuIndicatorResult[len];
+
+				for (var i = 0; i < len; i++)
+				{
+					var globalIdx = seriesOffsets[s] + i;
+					var resIdx = p * totalSize + globalIdx;
+					arr[i] = flatResults[resIdx];
+				}
+
+				result[s][p] = arr;
+			}
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// ILGPU kernel: ADL computation for multiple series and parameter sets. Results are stored as [param][globalIdx].
+	/// </summary>
+	private static void AdlParamsSeriesKernel(
+		Index2D index,
+		ArrayView<GpuCandle> flatCandles,
+		ArrayView<GpuIndicatorResult> flatResults,
+		ArrayView<int> offsets,
+		ArrayView<int> lengths,
+		ArrayView<GpuAdlParams> parameters)
+	{
+		var paramIdx = index.X;
+		var seriesIdx = index.Y;
+		_ = parameters;
+
+		var len = lengths[seriesIdx];
+
+		if (len == 0)
+			return;
+
+		var offset = offsets[seriesIdx];
+		var adLine = 0f;
+
+		for (var i = 0; i < len; i++)
+		{
+			var globalIdx = offset + i;
+			var candle = flatCandles[globalIdx];
+			var range = candle.High - candle.Low;
+
+			if (range != 0f)
+			{
+				var mfm = ((candle.Close - candle.Low) - (candle.High - candle.Close)) / range;
+				var mfv = mfm * candle.Volume;
+				adLine += mfv;
+			}
+
+			var resIdx = paramIdx * flatCandles.Length + globalIdx;
+			flatResults[resIdx] = new()
+			{
+				Time = candle.Time,
+				Value = adLine,
+				IsFormed = 1,
+			};
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a GPU implementation of the Accumulation/Distribution Line indicator with parameter struct and ILGPU kernel
- flatten and rebuild candle data to provide ADL results per series and parameter set

## Testing
- dotnet build Algo.Gpu/Algo.Gpu.csproj *(fails: dotnet command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2533a63f0832385148a721bb7e1a4