### PR TITLE
Fix critical bugs in Diagram.Core

### DIFF
--- a/Diagram.Core/CompositionDiagramElement.cs
+++ b/Diagram.Core/CompositionDiagramElement.cs
@@ -553,7 +553,7 @@ public class CompositionDiagramElement : DiagramElement
 			get
 			{
 				var node = InternalNode;
-				return (Directon == DiagramSocketDirection.In ? node?.InputSockets : node?.OutputSockets)?.FindById(InternalSocketId);
+				return (Direction == DiagramSocketDirection.In ? node?.InputSockets : node?.OutputSockets)?.FindById(InternalSocketId);
 			}
 		}
 	}
@@ -570,7 +570,7 @@ public class CompositionDiagramElement : DiagramElement
 		var sockets = Model.GetDisconnectedSockets().ToArray();
 
 		static (string nodeKey, DiagramSocketDirection dir, string socketId, DiagramSocketType sockType, int linkMax) CreateSocketKey(string nodeKey, DiagramSocket socket)
-			=> (nodeKey, socket?.Directon ?? DiagramSocketDirection.In, socket?.Id, socket?.Type, socket?.LinkableMaximum ?? 0);
+			=> (nodeKey, socket?.Direction ?? DiagramSocketDirection.In, socket?.Id, socket?.Type, socket?.LinkableMaximum ?? 0);
 
 		var needKeys = sockets.Select(s => CreateSocketKey(s.nodeKey, s.socket)).ToSet();
 
@@ -610,7 +610,7 @@ public class CompositionDiagramElement : DiagramElement
 				else
 				{
 					var newSocketId = GenerateSocketId(nodeKey, socket.Id);
-					var newSocket = (CompositionSocket)(socket.Directon == DiagramSocketDirection.In ? AddInput(newSocketId, socket.Name, socket.Type, linkableMax: socket.LinkableMaximum) : AddOutput(newSocketId, socket.Name, socket.Type, linkableMax: socket.LinkableMaximum));
+					var newSocket = (CompositionSocket)(socket.Direction == DiagramSocketDirection.In ? AddInput(newSocketId, socket.Name, socket.Type, linkableMax: socket.LinkableMaximum) : AddOutput(newSocketId, socket.Name, socket.Type, linkableMax: socket.LinkableMaximum));
 
 					newSocket.InternalNodeKey = nodeKey;
 					newSocket.InternalSocketId = socket.Id;

--- a/Diagram.Core/DiagramDebugger.cs
+++ b/Diagram.Core/DiagramDebugger.cs
@@ -414,7 +414,7 @@ public class DiagramDebugger : Disposable, IDebugger
 				continue;
 
 			if (_breakpoints.ContainsKey(socket))
-				return;
+				continue;
 
 			var obj = CreateSocketBreakpoint(socket);
 			obj.Load(breakPoint);

--- a/Diagram.Core/DiagramElement.cs
+++ b/Diagram.Core/DiagramElement.cs
@@ -554,7 +554,7 @@ public abstract class DiagramElement : BaseLogReceiver, INotifyPropertyChanging,
 
 		using var _ = SaveUndoState();
 
-		if(!GetSockets(socket.Directon).Remove(socket))
+		if(!GetSockets(socket.Direction).Remove(socket))
 			return;
 
 		socket.Connected -= OnSocketConnected;

--- a/Diagram.Core/DiagramSocket.cs
+++ b/Diagram.Core/DiagramSocket.cs
@@ -71,7 +71,7 @@ public class DiagramSocket : Disposable, INotifyPropertyChanged
 	/// <summary>
 	/// The connection direction.
 	/// </summary>
-	public DiagramSocketDirection Directon { get; }
+	public DiagramSocketDirection Direction { get; }
 
 	/// <summary>
 	/// Dynamic sockets are removed during Load().
@@ -214,7 +214,7 @@ public class DiagramSocket : Disposable, INotifyPropertyChanged
 		GuiWrapper = new DispatcherNotifiableObject<DiagramSocket>(ConfigManager.GetService<IDispatcher>(), this);
 
 		Id = socketId ?? Guid.NewGuid().ToN();
-		Directon = dir;
+		Direction = dir;
 		AvailableTypes = [];
 		this.ResetAvailableTypes();
 	}
@@ -265,12 +265,12 @@ public class DiagramSocket : Disposable, INotifyPropertyChanged
 	/// <summary>
 	/// Is input.
 	/// </summary>
-	public bool IsInput => Directon == DiagramSocketDirection.In;
+	public bool IsInput => Direction == DiagramSocketDirection.In;
 
 	/// <summary>
 	/// Is output.
 	/// </summary>
-	public bool IsOutput => Directon == DiagramSocketDirection.Out;
+	public bool IsOutput => Direction == DiagramSocketDirection.Out;
 
 	private readonly HashSet<DiagramSocket> _connections = [];
 
@@ -285,7 +285,7 @@ public class DiagramSocket : Disposable, INotifyPropertyChanged
 	/// <param name="other"><see cref="DiagramSocket"/></param>
 	public void Connect(DiagramSocket other)
 	{
-		if (other.Directon == Directon)
+		if (other.Direction == Direction)
 			throw new InvalidOperationException("invalid direction");
 
 		_connections.Add(other);

--- a/Diagram.Core/ICompositionModel.cs
+++ b/Diagram.Core/ICompositionModel.cs
@@ -514,7 +514,7 @@ public class CompositionModel<TNode, TLink> : ICompositionModel
 				.Where(s => ports.All(p => !p.EqualsIgnoreCase(s.Id)))
 				.Select(s =>
 				{
-					var socket = new DiagramSocket(s.Directon, s.Id)
+					var socket = new DiagramSocket(s.Direction, s.Id)
 					{
 						Name = $"{s.Name} - {node.Element.Name}",
 						Type = s.Type,


### PR DESCRIPTION
1. Fix typo: Rename property Directon -> Direction in DiagramSocket
   - Fixed property definition in DiagramSocket.cs
   - Updated all usages across DiagramElement.cs, CompositionDiagramElement.cs, ICompositionModel.cs

2. Fix logic error in DiagramDebugger.Load()
   - Changed 'return' to 'continue' when breakpoint already exists
   - This prevents skipping remaining breakpoints during load

🤖 Generated with [Claude Code](https://claude.com/claude-code)