### PR TITLE
Add CryptoHFTData historical market-data connector

### DIFF
--- a/Connectors/CryptoHFTData.Tests/CryptoHFTData.Tests.csproj
+++ b/Connectors/CryptoHFTData.Tests/CryptoHFTData.Tests.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\common_target_tests.props" />
+  <PropertyGroup>
+    <AssemblyName>StockSharp.CryptoHFTData.Tests</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CryptoHFTData\CryptoHFTData.csproj" />
+  </ItemGroup>
+</Project>

--- a/Connectors/CryptoHFTData.Tests/CryptoHFTDataClientTests.cs
+++ b/Connectors/CryptoHFTData.Tests/CryptoHFTDataClientTests.cs
@@ -1,0 +1,187 @@
+namespace StockSharp.CryptoHFTData.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Ecng.Common;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Parquet.Serialization;
+
+using StockSharp.CryptoHFTData.Native;
+
+using StockSharp.Messages;
+
+using ZstdSharp;
+
+[TestClass]
+public class CryptoHFTDataClientTests
+{
+	[TestMethod]
+	public async Task ListsSymbolsFromMetadataEndpoint()
+	{
+		var handler = new StubHandler(request =>
+		{
+			Assert.AreEqual("https://example.test/symbols?exchange=binance_futures&data_type=trades", request.RequestUri.ToString());
+			return Json("{\"symbols\":[\"BTCUSDT\",\"ETHUSDT\"]}");
+		});
+		using var client = new CryptoHFTDataClient("https://example.test", "key".Secure(), handler);
+
+		var symbols = await client.GetSymbols("binance_futures", "trades", CancellationToken.None);
+
+		CollectionAssert.AreEqual(new[] { "BTCUSDT", "ETHUSDT" }, symbols);
+	}
+
+	[TestMethod]
+	public async Task DownloadsAndDeserializesCompressedTrades()
+	{
+		var expected = new[]
+		{
+			new TradeRow
+			{
+				ReceivedTime = 1_783_728_004_885_015_486,
+				EventTime = 1_783_728_004_749,
+				TradeTime = 1_783_728_004_749,
+				Symbol = "KAVAUSDT",
+				TradeId = 404_761_086,
+				Price = "0.044570",
+				Quantity = "1353.4",
+				IsBuyerMaker = true,
+			},
+		};
+		var payload = await CompressParquet(expected);
+		var handler = new StubHandler(request =>
+		{
+			Assert.AreEqual("key", request.Headers.GetValues("X-API-Key").Single());
+			StringAssert.Contains(request.RequestUri.Query, Uri.EscapeDataString("binance_futures/2026-07-11/00/KAVAUSDT_trades.parquet.zst"));
+			return Bytes(payload);
+		});
+		using var client = new CryptoHFTDataClient("https://example.test", "key".Secure(), handler);
+
+		var rows = await client.GetTrades(
+			"binance_futures",
+			"KAVAUSDT",
+			new DateTime(2026, 7, 11, 0, 0, 0, DateTimeKind.Utc),
+			new DateTime(2026, 7, 11, 0, 59, 59, DateTimeKind.Utc),
+			CancellationToken.None);
+
+		Assert.HasCount(1, rows);
+		Assert.AreEqual(expected[0].TradeId, rows[0].TradeId);
+		Assert.AreEqual(expected[0].Price, rows[0].Price);
+		Assert.IsTrue(rows[0].IsBuyerMaker);
+	}
+
+	[TestMethod]
+	public async Task MissingHourlyFilesProduceNoRows()
+	{
+		var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+		using var client = new CryptoHFTDataClient("https://example.test", "key".Secure(), handler);
+
+		var rows = await client.GetOrderBook(
+			"bybit",
+			"BTCUSDT",
+			new DateTime(2026, 7, 11, 0, 0, 0, DateTimeKind.Utc),
+			new DateTime(2026, 7, 11, 0, 59, 59, DateTimeKind.Utc),
+			CancellationToken.None);
+
+		Assert.IsEmpty(rows);
+	}
+
+	[TestMethod]
+	public void MapsProviderRowsToStockSharpMessages()
+	{
+		var securityId = new SecurityId { SecurityCode = "KAVAUSDT", BoardCode = "binance_futures" };
+		var trade = new TradeRow
+		{
+			ReceivedTime = 1_783_728_004_885_015_486,
+			TradeTime = 1_783_728_004_749,
+			TradeId = 404_761_086,
+			Price = "0.044570",
+			Quantity = "1353.4",
+			IsBuyerMaker = true,
+		};
+
+		var tick = CryptoHFTDataMessageAdapter.ToExecutionMessage(trade, securityId, 42);
+
+		Assert.AreEqual(DataType.Ticks, tick.DataTypeEx);
+		Assert.AreEqual(0.044570m, tick.TradePrice);
+		Assert.AreEqual(1353.4m, tick.TradeVolume);
+		Assert.AreEqual(Sides.Sell, tick.OriginSide);
+		Assert.AreEqual(42, tick.OriginalTransactionId);
+
+		var depth = CryptoHFTDataMessageAdapter.ToQuoteChangeMessage(
+			[
+				new OrderBookRow { EventTime = 1_783_728_000_848, EventType = "update", FinalUpdateId = 100, Side = "bid", Price = "0.042360", Quantity = "70718.9" },
+				new OrderBookRow { EventTime = 1_783_728_000_848, EventType = "update", FinalUpdateId = 100, Side = "ask", Price = "0.044000", Quantity = "0" },
+			],
+			securityId,
+			43);
+
+		Assert.AreEqual(QuoteChangeStates.Increment, depth.State);
+		Assert.AreEqual(100, depth.SeqNum);
+		Assert.HasCount(1, depth.Bids);
+		Assert.HasCount(1, depth.Asks);
+		Assert.AreEqual(0m, depth.Asks[0].Volume);
+
+		var grouped = CryptoHFTDataMessageAdapter.GroupOrderBookRows(
+			[
+				new OrderBookRow { EventTime = 1, EventType = "update", FinalUpdateId = 1 },
+				new OrderBookRow { EventTime = 2, EventType = "snapshot", LastUpdateId = 2 },
+				new OrderBookRow { EventTime = 3, EventType = "update", FinalUpdateId = 3 },
+			]).ToArray();
+
+		Assert.HasCount(3, grouped);
+		Assert.AreEqual("update", grouped[0][0].EventType);
+	}
+
+	[TestMethod]
+	[TestCategory("Integration")]
+	public async Task DownloadsLiveTradesAndOrderBook()
+	{
+		if (!Environment.GetEnvironmentVariable("RUN_CRYPTOHFTDATA_LIVE_TESTS").EqualsIgnoreCase("true"))
+			Assert.Inconclusive("Set RUN_CRYPTOHFTDATA_LIVE_TESTS=true to run the live API test.");
+
+		using var client = new CryptoHFTDataClient(
+			"https://api.cryptohftdata.com",
+			Environment.GetEnvironmentVariable("CRYPTOHFTDATA_API_KEY")?.Secure());
+		var from = new DateTime(2026, 7, 11, 0, 0, 0, DateTimeKind.Utc);
+		var to = from.AddHours(1).AddTicks(-1);
+
+		var trades = await client.GetTrades("binance_futures", "KAVAUSDT", from, to, CancellationToken.None);
+		var orderBook = await client.GetOrderBook("binance_futures", "KAVAUSDT", from, to, CancellationToken.None);
+
+		Assert.IsNotEmpty(trades);
+		Assert.IsNotEmpty(orderBook);
+		Assert.IsTrue(trades.All(t => t.TradeTime >= new DateTimeOffset(from).ToUnixTimeMilliseconds()));
+		Assert.IsTrue(orderBook.All(q => q.EventTime >= new DateTimeOffset(from).ToUnixTimeMilliseconds()));
+	}
+
+	private static async Task<byte[]> CompressParquet<T>(IEnumerable<T> rows)
+		where T : class, new()
+	{
+		await using var parquet = new MemoryStream();
+		await ParquetSerializer.SerializeAsync(rows, parquet);
+		using var compressor = new Compressor();
+		return compressor.Wrap(parquet.ToArray()).ToArray();
+	}
+
+	private static HttpResponseMessage Json(string value)
+		=> new(HttpStatusCode.OK) { Content = new StringContent(value, Encoding.UTF8, "application/json") };
+
+	private static HttpResponseMessage Bytes(byte[] value)
+		=> new(HttpStatusCode.OK) { Content = new ByteArrayContent(value) };
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+			=> Task.FromResult(responseFactory(request));
+	}
+}

--- a/Connectors/CryptoHFTData/CryptoHFTData.csproj
+++ b/Connectors/CryptoHFTData/CryptoHFTData.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\common_connectors.props" />
+  <ItemGroup>
+    <PackageReference Include="Parquet.Net" Version="5.*" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.*" />
+  </ItemGroup>
+</Project>

--- a/Connectors/CryptoHFTData/CryptoHFTDataMessageAdapter.cs
+++ b/Connectors/CryptoHFTData/CryptoHFTDataMessageAdapter.cs
@@ -1,0 +1,64 @@
+namespace StockSharp.CryptoHFTData;
+
+/// <summary>
+/// Historical market-data adapter for CryptoHFTData.
+/// </summary>
+public partial class CryptoHFTDataMessageAdapter
+{
+	private CryptoHFTDataClient _client;
+
+	/// <summary>
+	/// Exchange identifiers published by the current CryptoHFTData SDK.
+	/// </summary>
+	public static IReadOnlyList<string> SupportedExchanges => CryptoHFTDataClient.Exchanges;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="CryptoHFTDataMessageAdapter"/>.
+	/// </summary>
+	public CryptoHFTDataMessageAdapter(IdGenerator transactionIdGenerator)
+		: base(transactionIdGenerator)
+	{
+		this.AddMarketDataSupport();
+		this.AddSupportedMarketDataType(DataType.Ticks);
+		this.AddSupportedMarketDataType(DataType.MarketDepth);
+	}
+
+	/// <inheritdoc />
+	public override bool IsSupportOrderBookIncrements => true;
+
+	/// <inheritdoc />
+	public override string[] AssociatedBoards => [Exchange];
+
+	/// <inheritdoc />
+	protected override ValueTask ConnectAsync(ConnectMessage connectMsg, CancellationToken cancellationToken)
+	{
+		if (_client is not null)
+			throw new InvalidOperationException(LocalizedStrings.NotDisconnectPrevTime);
+
+		_client = new(Address, Token) { Parent = this };
+		return SendOutMessageAsync(new ConnectMessage(), cancellationToken);
+	}
+
+	/// <inheritdoc />
+	protected override ValueTask DisconnectAsync(DisconnectMessage disconnectMsg, CancellationToken cancellationToken)
+	{
+		if (_client is null)
+			throw new InvalidOperationException(LocalizedStrings.ConnectionNotOk);
+
+		_client.Dispose();
+		_client = null;
+		return SendOutMessageAsync(new DisconnectMessage(), cancellationToken);
+	}
+
+	/// <inheritdoc />
+	protected override async ValueTask ResetAsync(ResetMessage resetMsg, CancellationToken cancellationToken)
+	{
+		_client?.Dispose();
+		_client = null;
+		await SendOutMessageAsync(new ResetMessage(), cancellationToken);
+	}
+
+	/// <inheritdoc />
+	protected override ValueTask TimeAsync(TimeMessage timeMsg, CancellationToken cancellationToken)
+		=> default;
+}

--- a/Connectors/CryptoHFTData/CryptoHFTDataMessageAdapter_MarketData.cs
+++ b/Connectors/CryptoHFTData/CryptoHFTDataMessageAdapter_MarketData.cs
@@ -1,0 +1,154 @@
+namespace StockSharp.CryptoHFTData;
+
+public partial class CryptoHFTDataMessageAdapter
+{
+	/// <inheritdoc />
+	protected override async ValueTask SecurityLookupAsync(SecurityLookupMessage lookupMsg, CancellationToken cancellationToken)
+	{
+		EnsureConnected();
+		var symbols = (await _client.GetSymbols(Exchange, "trades", cancellationToken))
+			.Union(await _client.GetSymbols(Exchange, "orderbook", cancellationToken))
+			.Distinct(StringComparer.OrdinalIgnoreCase);
+		var left = lookupMsg.Count ?? long.MaxValue;
+
+		foreach (var symbol in symbols)
+		{
+			var security = new SecurityMessage
+			{
+				SecurityId = new() { SecurityCode = symbol, BoardCode = Exchange },
+				Name = symbol,
+				SecurityType = Exchange.Contains("futures", StringComparison.OrdinalIgnoreCase) || Exchange is "bybit" or "bitmex"
+					? SecurityTypes.Future
+					: SecurityTypes.CryptoCurrency,
+				OriginalTransactionId = lookupMsg.TransactionId,
+			};
+
+			if (!security.IsMatch(lookupMsg, lookupMsg.GetSecurityTypes()))
+				continue;
+
+			await SendOutMessageAsync(security, cancellationToken);
+			if (--left <= 0)
+				break;
+		}
+
+		await SendSubscriptionResultAsync(lookupMsg, cancellationToken);
+	}
+
+	/// <inheritdoc />
+	protected override async ValueTask OnTicksSubscriptionAsync(MarketDataMessage mdMsg, CancellationToken cancellationToken)
+	{
+		await SendSubscriptionReplyAsync(mdMsg.TransactionId, cancellationToken);
+		if (!mdMsg.IsSubscribe)
+			return;
+
+		EnsureConnected();
+		var (from, to) = GetRange(mdMsg);
+		var left = mdMsg.Count ?? long.MaxValue;
+
+		foreach (var trade in (await _client.GetTrades(Exchange, mdMsg.SecurityId.SecurityCode, from, to, cancellationToken)).OrderBy(t => t.TradeTime))
+		{
+			var time = FromUnixMilliseconds(trade.TradeTime);
+			if (time < from || time > to)
+				continue;
+
+			await SendOutMessageAsync(ToExecutionMessage(trade, mdMsg.SecurityId, mdMsg.TransactionId), cancellationToken);
+
+			if (--left <= 0)
+				break;
+		}
+
+		await SendSubscriptionFinishedAsync(mdMsg.TransactionId, cancellationToken);
+	}
+
+	/// <inheritdoc />
+	protected override async ValueTask OnMarketDepthSubscriptionAsync(MarketDataMessage mdMsg, CancellationToken cancellationToken)
+	{
+		await SendSubscriptionReplyAsync(mdMsg.TransactionId, cancellationToken);
+		if (!mdMsg.IsSubscribe)
+			return;
+
+		EnsureConnected();
+		var (from, to) = GetRange(mdMsg);
+		var left = mdMsg.Count ?? long.MaxValue;
+		var rows = await _client.GetOrderBook(Exchange, mdMsg.SecurityId.SecurityCode, from, to, cancellationToken);
+
+		foreach (var group in GroupOrderBookRows(rows))
+		{
+			var time = FromUnixMilliseconds(group[0].EventTime);
+			if (time < from || time > to)
+				continue;
+
+			await SendOutMessageAsync(ToQuoteChangeMessage(group, mdMsg.SecurityId, mdMsg.TransactionId), cancellationToken);
+
+			if (--left <= 0)
+				break;
+		}
+
+		await SendSubscriptionFinishedAsync(mdMsg.TransactionId, cancellationToken);
+	}
+
+	private static (DateTime from, DateTime to) GetRange(MarketDataMessage message)
+	{
+		if (message.From is null)
+			throw new ArgumentException("Historical CryptoHFTData subscriptions require From.", nameof(message));
+		return (message.From.Value.ToUniversalTime(), (message.To ?? message.From).Value.ToUniversalTime());
+	}
+
+	private static DateTime FromUnixMilliseconds(long value)
+		=> DateTimeOffset.FromUnixTimeMilliseconds(value).UtcDateTime;
+
+	private static DateTime FromUnixNanoseconds(long value)
+		=> DateTimeOffset.FromUnixTimeMilliseconds(value / 1_000_000).UtcDateTime.AddTicks(value % 1_000_000 / 100);
+
+	internal static ExecutionMessage ToExecutionMessage(TradeRow trade, SecurityId securityId, long transactionId)
+		=> new()
+		{
+			DataTypeEx = DataType.Ticks,
+			SecurityId = securityId,
+			TradeId = trade.TradeId,
+			TradePrice = trade.Price.To<decimal>(),
+			TradeVolume = trade.Quantity.To<decimal>(),
+			ServerTime = FromUnixMilliseconds(trade.TradeTime),
+			LocalTime = FromUnixNanoseconds(trade.ReceivedTime),
+			OriginSide = trade.IsBuyerMaker ? Sides.Sell : Sides.Buy,
+			OriginalTransactionId = transactionId,
+		};
+
+	internal static QuoteChangeMessage ToQuoteChangeMessage(IReadOnlyCollection<OrderBookRow> rows, SecurityId securityId, long transactionId)
+	{
+		if (rows.Count == 0)
+			throw new ArgumentException("An order-book event must contain at least one row.", nameof(rows));
+
+		var first = rows.First();
+		var changes = rows
+			.Select(r => (row: r, quote: new QuoteChange(r.Price.To<decimal>(), r.Quantity.To<decimal>())))
+			.ToArray();
+
+		return new()
+		{
+			SecurityId = securityId,
+			Bids = changes.Where(c => c.row.Side.EqualsIgnoreCase("bid")).Select(c => c.quote).ToArray(),
+			Asks = changes.Where(c => c.row.Side.EqualsIgnoreCase("ask")).Select(c => c.quote).ToArray(),
+			ServerTime = FromUnixMilliseconds(first.EventTime),
+			SeqNum = first.SequenceNumber,
+			State = first.EventType.EqualsIgnoreCase("snapshot")
+				? QuoteChangeStates.SnapshotComplete
+				: QuoteChangeStates.Increment,
+			OriginalTransactionId = transactionId,
+		};
+	}
+
+	internal static IEnumerable<IReadOnlyList<OrderBookRow>> GroupOrderBookRows(IEnumerable<OrderBookRow> rows)
+	{
+		foreach (var group in rows
+			.OrderBy(r => r.EventTime)
+			.GroupBy(r => new { r.EventTime, r.EventType, r.SequenceNumber }))
+			yield return group.ToArray();
+	}
+
+	private void EnsureConnected()
+	{
+		if (_client is null)
+			throw new InvalidOperationException(LocalizedStrings.ConnectionNotOk);
+	}
+}

--- a/Connectors/CryptoHFTData/CryptoHFTDataMessageAdapter_Settings.cs
+++ b/Connectors/CryptoHFTData/CryptoHFTDataMessageAdapter_Settings.cs
@@ -1,0 +1,48 @@
+﻿namespace StockSharp.CryptoHFTData;
+
+using System.ComponentModel.DataAnnotations;
+
+/// <summary>
+/// Historical market-data adapter for CryptoHFTData.
+/// </summary>
+[Display(Name = "CryptoHFTData", Description = "Historical cryptocurrency trades and order books.", GroupName = "Cryptocurrency")]
+[MessageAdapterCategory(MessageAdapterCategories.Crypto | MessageAdapterCategories.History |
+	MessageAdapterCategories.Free | MessageAdapterCategories.Ticks | MessageAdapterCategories.MarketDepth)]
+public partial class CryptoHFTDataMessageAdapter : MessageAdapter, ITokenAdapter, IAddressAdapter<string>
+{
+	/// <inheritdoc />
+	[Display(Name = "API key", Description = "Optional CryptoHFTData API key. Keyless access uses the rate-limited free tier.", GroupName = "Connection", Order = 0)]
+	[BasicSetting]
+	public SecureString Token { get; set; }
+
+	/// <summary>
+	/// CryptoHFTData exchange identifier, such as <c>binance_futures</c>.
+	/// </summary>
+	[Display(Name = "Exchange", Description = "CryptoHFTData exchange identifier.", GroupName = "Connection", Order = 1)]
+	[BasicSetting]
+	public string Exchange { get; set; } = "binance_futures";
+
+	/// <inheritdoc />
+	[Display(Name = "API address", Description = "CryptoHFTData API base address.", GroupName = "Connection", Order = 2)]
+	[BasicSetting]
+	public string Address { get; set; } = "https://api.cryptohftdata.com";
+
+	/// <inheritdoc />
+	public override void Save(SettingsStorage storage)
+	{
+		base.Save(storage);
+		storage
+			.Set(nameof(Token), Token)
+			.Set(nameof(Exchange), Exchange)
+			.Set(nameof(Address), Address);
+	}
+
+	/// <inheritdoc />
+	public override void Load(SettingsStorage storage)
+	{
+		base.Load(storage);
+		Token = storage.GetValue<SecureString>(nameof(Token));
+		Exchange = storage.GetValue<string>(nameof(Exchange), Exchange);
+		Address = storage.GetValue<string>(nameof(Address), Address);
+	}
+}

--- a/Connectors/CryptoHFTData/Native/CryptoHFTDataClient.cs
+++ b/Connectors/CryptoHFTData/Native/CryptoHFTDataClient.cs
@@ -1,0 +1,150 @@
+namespace StockSharp.CryptoHFTData.Native;
+
+using Parquet.Serialization;
+
+using ZstdSharp;
+
+sealed class CryptoHFTDataClient : BaseLogReceiver
+{
+	public static readonly string[] Exchanges =
+	[
+		"binance_spot", "binance_futures", "bybit_spot", "bybit",
+		"kraken_spot", "kraken_derivatives", "okx_spot", "okx_futures",
+		"bitget_spot", "bitget_futures", "hyperliquid_spot", "hyperliquid_futures",
+		"lighter", "aster_futures", "bitmex",
+	];
+
+	private readonly System.Net.Http.HttpClient _httpClient;
+	private readonly string _baseAddress;
+	private readonly string _apiKey;
+	private readonly SemaphoreSlim _freeTierLock = new(1, 1);
+	private DateTime _lastFreeTierRequest;
+
+	public CryptoHFTDataClient(string baseAddress, SecureString apiKey, HttpMessageHandler handler = null)
+	{
+		_baseAddress = baseAddress?.TrimEnd('/') ?? throw new ArgumentNullException(nameof(baseAddress));
+		_apiKey = apiKey?.UnSecure();
+		_httpClient = handler is null ? new() : new(handler);
+		_httpClient.Timeout = TimeSpan.FromSeconds(30);
+		_httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("StockSharp.CryptoHFTData/1.0");
+	}
+
+	public override string Name => nameof(CryptoHFTData) + "_" + nameof(CryptoHFTDataClient);
+
+	public async Task<string[]> GetSymbols(string exchange, string dataType, CancellationToken cancellationToken)
+	{
+		ValidateExchange(exchange);
+
+		var url = $"{_baseAddress}/symbols?exchange={Uri.EscapeDataString(exchange)}&data_type={Uri.EscapeDataString(dataType)}";
+		using var response = await _httpClient.GetAsync(url, cancellationToken);
+		response.EnsureSuccessStatusCode();
+		await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		var result = await JsonSerializer.DeserializeAsync<SymbolsResponse>(stream, cancellationToken: cancellationToken);
+		return result?.Symbols ?? [];
+	}
+
+	public Task<IReadOnlyList<TradeRow>> GetTrades(string exchange, string symbol, DateTime from, DateTime to, CancellationToken cancellationToken)
+		=> DownloadRange<TradeRow>(exchange, symbol, "trades", from, to, cancellationToken);
+
+	public Task<IReadOnlyList<OrderBookRow>> GetOrderBook(string exchange, string symbol, DateTime from, DateTime to, CancellationToken cancellationToken)
+		=> DownloadRange<OrderBookRow>(exchange, symbol, "orderbook", from, to, cancellationToken);
+
+	private async Task<IReadOnlyList<T>> DownloadRange<T>(string exchange, string symbol, string dataType, DateTime from, DateTime to, CancellationToken cancellationToken)
+		where T : class, new()
+	{
+		ValidateExchange(exchange);
+
+		if (symbol.IsEmpty())
+			throw new ArgumentNullException(nameof(symbol));
+		if (to < from)
+			throw new ArgumentOutOfRangeException(nameof(to), to, "End time must not precede start time.");
+
+		var rows = new List<T>();
+		var hour = new DateTime(from.Year, from.Month, from.Day, from.Hour, 0, 0, DateTimeKind.Utc);
+		var lastHour = new DateTime(to.Year, to.Month, to.Day, to.Hour, 0, 0, DateTimeKind.Utc);
+
+		while (hour <= lastHour)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			var path = $"{exchange}/{hour:yyyy-MM-dd}/{hour:HH}/{symbol}_{dataType}.parquet.zst";
+			rows.AddRange(await DownloadFile<T>(path, cancellationToken));
+			hour = hour.AddHours(1);
+		}
+
+		return rows;
+	}
+
+	private async Task<IReadOnlyList<T>> DownloadFile<T>(string path, CancellationToken cancellationToken)
+		where T : class, new()
+	{
+		if (_apiKey.IsEmpty())
+			await WaitForFreeTier(cancellationToken);
+
+		var url = $"{_baseAddress}/download?file={Uri.EscapeDataString(path)}";
+		using var response = await SendWithRetries(url, cancellationToken);
+		if (response.StatusCode == HttpStatusCode.NotFound)
+			return [];
+		response.EnsureSuccessStatusCode();
+
+		var payload = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+		if (payload.Length == 0)
+			return [];
+
+		if (!payload.AsSpan().StartsWith("PAR1"u8))
+		{
+			using var decompressor = new Decompressor();
+			payload = decompressor.Unwrap(payload).ToArray();
+		}
+
+		await using var stream = new MemoryStream(payload, writable: false);
+		var result = await ParquetSerializer.DeserializeAsync<T>(stream, cancellationToken: cancellationToken);
+		return result.ToArray();
+	}
+
+	private async Task<HttpResponseMessage> SendWithRetries(string url, CancellationToken cancellationToken)
+	{
+		for (var attempt = 0; ; attempt++)
+		{
+			using var request = new HttpRequestMessage(HttpMethod.Get, url);
+			if (!_apiKey.IsEmpty())
+				request.Headers.Add("X-API-Key", _apiKey);
+
+			var response = await _httpClient.SendAsync(request, cancellationToken);
+			if (response.StatusCode != HttpStatusCode.TooManyRequests || attempt >= 3)
+				return response;
+
+			var delay = response.Headers.RetryAfter?.Delta ?? TimeSpan.FromSeconds(Math.Pow(2, attempt));
+			response.Dispose();
+			await Task.Delay(delay, cancellationToken);
+		}
+	}
+
+	private async Task WaitForFreeTier(CancellationToken cancellationToken)
+	{
+		await _freeTierLock.WaitAsync(cancellationToken);
+		try
+		{
+			var delay = _lastFreeTierRequest.AddSeconds(1) - DateTime.UtcNow;
+			if (delay > TimeSpan.Zero)
+				await Task.Delay(delay, cancellationToken);
+			_lastFreeTierRequest = DateTime.UtcNow;
+		}
+		finally
+		{
+			_freeTierLock.Release();
+		}
+	}
+
+	private static void ValidateExchange(string exchange)
+	{
+		if (exchange.IsEmpty())
+			throw new ArgumentNullException(nameof(exchange));
+	}
+
+	protected override void DisposeManaged()
+	{
+		_httpClient.Dispose();
+		_freeTierLock.Dispose();
+		base.DisposeManaged();
+	}
+}

--- a/Connectors/CryptoHFTData/Native/Models.cs
+++ b/Connectors/CryptoHFTData/Native/Models.cs
@@ -1,0 +1,80 @@
+namespace StockSharp.CryptoHFTData.Native;
+
+using Parquet.Serialization.Attributes;
+
+sealed class SymbolsResponse
+{
+	[JsonPropertyName("symbols")]
+	public string[] Symbols { get; set; } = [];
+}
+
+sealed class TradeRow
+{
+	[JsonPropertyName("received_time")]
+	public long ReceivedTime { get; set; }
+
+	[JsonPropertyName("event_time")]
+	public long EventTime { get; set; }
+
+	[JsonPropertyName("symbol")]
+	[ParquetRequired]
+	public string Symbol { get; set; }
+
+	[JsonPropertyName("trade_id")]
+	public long TradeId { get; set; }
+
+	[JsonPropertyName("price")]
+	[ParquetRequired]
+	public string Price { get; set; }
+
+	[JsonPropertyName("quantity")]
+	[ParquetRequired]
+	public string Quantity { get; set; }
+
+	[JsonPropertyName("trade_time")]
+	public long TradeTime { get; set; }
+
+	[JsonPropertyName("is_buyer_maker")]
+	public bool IsBuyerMaker { get; set; }
+}
+
+sealed class OrderBookRow
+{
+	[JsonPropertyName("received_time")]
+	public long ReceivedTime { get; set; }
+
+	[JsonPropertyName("event_time")]
+	public long EventTime { get; set; }
+
+	[JsonPropertyName("symbol")]
+	[ParquetRequired]
+	public string Symbol { get; set; }
+
+	[JsonPropertyName("event_type")]
+	[ParquetRequired]
+	public string EventType { get; set; }
+
+	[JsonPropertyName("first_update_id")]
+	public long? FirstUpdateId { get; set; }
+
+	[JsonPropertyName("final_update_id")]
+	public long? FinalUpdateId { get; set; }
+
+	[JsonPropertyName("last_update_id")]
+	public long? LastUpdateId { get; set; }
+
+	[JsonPropertyName("side")]
+	[ParquetRequired]
+	public string Side { get; set; }
+
+	[JsonPropertyName("price")]
+	[ParquetRequired]
+	public string Price { get; set; }
+
+	[JsonPropertyName("quantity")]
+	[ParquetRequired]
+	public string Quantity { get; set; }
+
+	[JsonIgnore]
+	public long SequenceNumber => FinalUpdateId ?? LastUpdateId ?? 0;
+}

--- a/Connectors/CryptoHFTData/Properties/AssemblyInfo.cs
+++ b/Connectors/CryptoHFTData/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("StockSharp.CryptoHFTData.Tests")]

--- a/Connectors/CryptoHFTData/Properties/usings.cs
+++ b/Connectors/CryptoHFTData/Properties/usings.cs
@@ -1,0 +1,20 @@
+﻿global using global::System;
+global using global::System.Collections.Generic;
+global using global::System.IO;
+global using global::System.Linq;
+global using global::System.Net;
+global using global::System.Net.Http;
+global using global::System.Security;
+global using global::System.Text.Json;
+global using global::System.Text.Json.Serialization;
+global using global::System.Threading;
+global using global::System.Threading.Tasks;
+
+global using global::Ecng.Common;
+global using global::Ecng.ComponentModel;
+global using global::Ecng.Logging;
+global using global::Ecng.Serialization;
+
+global using global::StockSharp.Localization;
+global using global::StockSharp.Messages;
+global using global::StockSharp.CryptoHFTData.Native;

--- a/Connectors/CryptoHFTData/README.md
+++ b/Connectors/CryptoHFTData/README.md
@@ -1,0 +1,53 @@
+# CryptoHFTData Connector
+
+This connector adds [CryptoHFTData](https://cryptohftdata.com) as a historical
+cryptocurrency market-data source for StockSharp. It downloads the provider's
+hourly Parquet/Zstandard files directly and emits native StockSharp messages.
+
+## Supported data
+
+- historical trades as `ExecutionMessage` ticks
+- historical order-book snapshots and incremental `QuoteChangeMessage` updates
+- symbol discovery for the selected exchange
+- anonymous free-tier downloads or authenticated downloads with an API key
+
+CryptoHFTData is historical-only and does not provide order routing or live
+streaming. Timestamps are normalized to UTC; maker-side flags are converted to
+the aggressor side used by StockSharp. Order-book event types are preserved:
+provider snapshots become `SnapshotComplete` messages and update rows become
+sequenced increments. Some exchange intervals contain updates only, so consumers
+that require a fully initialized book should include their normal warm-up range.
+
+## Usage
+
+```csharp
+var adapter = new CryptoHFTDataMessageAdapter(new IncrementalIdGenerator())
+{
+    Exchange = "binance_futures",
+    Token = Environment.GetEnvironmentVariable("CRYPTOHFTDATA_API_KEY")?.Secure(),
+};
+
+var connector = new Connector();
+connector.Adapter.InnerAdapters.Add(adapter);
+connector.SubscriptionsOnConnect.Clear();
+connector.Connect();
+
+var security = new Security
+{
+    Id = "KAVAUSDT@binance_futures",
+    Code = "KAVAUSDT",
+    Board = ExchangeBoard.GetOrCreateBoard("binance_futures"),
+};
+var subscription = new Subscription(DataType.Ticks, security)
+{
+    From = new DateTimeOffset(2026, 7, 11, 0, 0, 0, TimeSpan.Zero),
+    To = new DateTimeOffset(2026, 7, 11, 0, 59, 59, TimeSpan.Zero),
+};
+connector.Subscribe(subscription);
+```
+
+Use one of the exchange identifiers returned by CryptoHFTData, such as
+`binance_spot`, `binance_futures`, `bybit`, `okx_futures`, or
+`hyperliquid_futures`. The API key is optional; keyless downloads are paced to
+the free-tier limit of 60 requests per minute. Set `Token` from
+`CRYPTOHFTDATA_API_KEY` for account-level limits.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ connector.Connect();
 |<img src="./Media/logos/CoinExchange_logo.png" height="30" /> |CoinExchange | <a href="//doc.stocksharp.com/topics/api/connectors/crypto_exchanges/coinexchange.html" target="_blank">Docs</a> |
 |<img src="./Media/logos/coinigy_logo.svg" height="30" /> |Coinigy  | <a href="//doc.stocksharp.com/topics/api/connectors/crypto_exchanges/coinigy.html" target="_blank">Docs</a> |
 |<img src="./Media/logos/coinhub_logo.svg" height="30" /> |CoinHub | <a href="//doc.stocksharp.com/topics/api/connectors/crypto_exchanges/coinhub.html" target="_blank">Docs</a> |
+| |CryptoHFTData | [Docs](./Connectors/CryptoHFTData/README.md) |
 |<img src="./Media/logos/cryptopia_logo.svg" height="30" /> |Cryptopia | <a href="//doc.stocksharp.com/topics/api/connectors/crypto_exchanges/cryptopia.html" target="_blank">Docs</a> |
 |<img src="./Media/logos/deribit_logo.svg" height="30" /> |Deribit | <a href="//doc.stocksharp.com/topics/api/connectors/crypto_exchanges/deribit.html" target="_blank">Docs</a> |
 |<img src="./Media/logos/digifinex_logo.svg" height="30" /> |DigiFinex | <a href="//doc.stocksharp.com/topics/api/connectors/crypto_exchanges/digifinex.html" target="_blank">Docs</a> |
@@ -213,4 +214,3 @@ connector.Connect();
   [10]: https://stocksharp.com/store/trading-terminal/
   [11]: https://stocksharp.com/store/trading-shell/
   [12]: https://stocksharp.com/store/api/
-

--- a/Samples/10_CrossPlatform/02_CryptoHFTDataHistory/02_CrossPlatform.CryptoHFTDataHistory.csproj
+++ b/Samples/10_CrossPlatform/02_CryptoHFTDataHistory/02_CrossPlatform.CryptoHFTDataHistory.csproj
@@ -1,0 +1,6 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\common_samples_net.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Connectors\CryptoHFTData\CryptoHFTData.csproj" />
+  </ItemGroup>
+</Project>

--- a/Samples/10_CrossPlatform/02_CryptoHFTDataHistory/Program.cs
+++ b/Samples/10_CrossPlatform/02_CryptoHFTDataHistory/Program.cs
@@ -1,0 +1,70 @@
+﻿namespace StockSharp.Samples.CrossPlatform.CryptoHFTDataHistory;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Ecng.Common;
+
+using StockSharp.CryptoHFTData;
+using StockSharp.Messages;
+
+static class Program
+{
+	private static async Task Main()
+	{
+		var adapter = new CryptoHFTDataMessageAdapter(new IncrementalIdGenerator())
+		{
+			Exchange = "binance_futures",
+			Token = Environment.GetEnvironmentVariable("CRYPTOHFTDATA_API_KEY")?.Secure(),
+		};
+
+		adapter.NewOutMessageAsync += (message, _) =>
+		{
+			switch (message)
+			{
+				case ExecutionMessage trade:
+					Console.WriteLine($"trade {trade.ServerTime:O} {trade.TradePrice} x {trade.TradeVolume} {trade.OriginSide}");
+					break;
+				case QuoteChangeMessage depth:
+					Console.WriteLine($"depth {depth.ServerTime:O} bids={depth.Bids.Length} asks={depth.Asks.Length} state={depth.State}");
+					break;
+			}
+			return default;
+		};
+
+		await adapter.SendInMessageAsync(new ConnectMessage(), CancellationToken.None);
+
+		var securityId = new SecurityId
+		{
+			SecurityCode = "KAVAUSDT",
+			BoardCode = adapter.Exchange,
+		};
+		var from = new DateTime(2026, 7, 11, 0, 0, 0, DateTimeKind.Utc);
+		var to = from.AddHours(1).AddTicks(-1);
+
+		await adapter.SendInMessageAsync(new MarketDataMessage
+		{
+			IsSubscribe = true,
+			TransactionId = 1,
+			SecurityId = securityId,
+			DataType2 = DataType.Ticks,
+			From = from,
+			To = to,
+			Count = 10,
+		}, CancellationToken.None);
+
+		await adapter.SendInMessageAsync(new MarketDataMessage
+		{
+			IsSubscribe = true,
+			TransactionId = 2,
+			SecurityId = securityId,
+			DataType2 = DataType.MarketDepth,
+			From = from,
+			To = to,
+			Count = 10,
+		}, CancellationToken.None);
+
+		await adapter.SendInMessageAsync(new DisconnectMessage(), CancellationToken.None);
+	}
+}

--- a/Samples/10_CrossPlatform/02_CryptoHFTDataHistory/README.md
+++ b/Samples/10_CrossPlatform/02_CryptoHFTDataHistory/README.md
@@ -1,0 +1,14 @@
+# CryptoHFTData historical market data
+
+This cross-platform console sample downloads one hour of KAVAUSDT trades and
+order-book updates through `CryptoHFTDataMessageAdapter` and prints the first ten
+native StockSharp messages of each type.
+
+Run it from the repository root:
+
+```bash
+dotnet run --project Samples/10_CrossPlatform/02_CryptoHFTDataHistory
+```
+
+No credentials are required for the rate-limited free tier. Set
+`CRYPTOHFTDATA_API_KEY` to use account-level limits.

--- a/StockSharp.slnx
+++ b/StockSharp.slnx
@@ -7,6 +7,8 @@
     <Project Path="Connectors/Bittrex/Bittrex.csproj" />
     <Project Path="Connectors/Btce/Btce.csproj" />
     <Project Path="Connectors/Coinbase/Coinbase.csproj" />
+    <Project Path="Connectors/CryptoHFTData/CryptoHFTData.csproj" />
+    <Project Path="Connectors/CryptoHFTData.Tests/CryptoHFTData.Tests.csproj" />
     <Project Path="Connectors/FTX/FTX.csproj" />
     <Project Path="Connectors/PrizmBit/PrizmBit.csproj" />
     <Project Path="Connectors/Tinkoff/Tinkoff.csproj" />
@@ -67,6 +69,7 @@
   </Folder>
   <Folder Name="/Samples/10_CrossPlatform/">
     <Project Path="Samples/10_CrossPlatform/01_ConsoleApp/01_CrossPlatform.ConsoleApp.csproj" />
+    <Project Path="Samples/10_CrossPlatform/02_CryptoHFTDataHistory/02_CrossPlatform.CryptoHFTDataHistory.csproj" />
   </Folder>
   <Project Path="Alerts.Interfaces/Alerts.Interfaces.csproj" />
   <Project Path="Algo.Analytics.CSharp/Algo.Analytics.CSharp.csproj" />

--- a/StockSharp_Tests.slnx
+++ b/StockSharp_Tests.slnx
@@ -13,6 +13,7 @@
   <Project Path="BusinessEntities/BusinessEntities.csproj" />
   <Project Path="Charting.Interfaces/Charting.Interfaces.csproj" />
   <Project Path="Configuration/Configuration.csproj" />
+  <Project Path="Connectors/CryptoHFTData.Tests/CryptoHFTData.Tests.csproj" />
   <Project Path="Diagram.Core/Diagram.Core.csproj" />
   <Project Path="Localization.Generator/Localization.Generator.csproj" />
   <Project Path="Localization/Localization.csproj" />


### PR DESCRIPTION
## Summary

Adds CryptoHFTData as a native, historical-only StockSharp market-data connector.

- discovers symbols for a configured CryptoHFTData exchange
- downloads the provider's hourly Parquet/Zstandard files directly in .NET
- emits historical trades as native `ExecutionMessage` ticks
- emits grouped order-book rows as sequenced `QuoteChangeMessage` snapshots or increments
- maps buyer-maker flags to StockSharp's aggressor side and preserves provider timestamps and update IDs
- supports anonymous, paced free-tier access and optional `X-API-Key` authentication
- skips missing hourly files while retaining cancellation, retry, and 429 backoff behavior
- adds deterministic tests, a gated live integration test, connector documentation, and a cross-platform console sample

Order-book event semantics are preserved rather than inferred. Some venue intervals contain update-only data; users who require a fully initialized book should include their normal warm-up range.

Disclosure: I am the creator of CryptoHFTData.

## Validation

- `dotnet build StockSharp_Tests.slnx --configuration Release` (succeeded; only existing obsolete/XML-doc warnings)
- connector tests: 4 passed, 1 gated live test skipped by default
- gated keyless live test: real KAVAUSDT trades and order-book data from `binance_futures`, 2026-07-11 00:00–00:59
- cross-platform sample build: 0 warnings, 0 errors
- keyless sample run emitted correctly normalized StockSharp trade and depth messages

The full existing `StockSharp_Tests.slnx` run exposed unrelated baseline failures in locale-sensitive weighted-index parsing, the Python analytics environment (`Indicators` module missing), and a memory-leak threshold test; it was stopped while other long-running tests continued. The new connector test assembly completed successfully in that run.
