### PR TITLE
Preserve FIFO priority after interior cancellations

### DIFF
--- a/MatchingEngine/OrderBook.cs
+++ b/MatchingEngine/OrderBook.cs
@@ -5,36 +5,55 @@ namespace StockSharp.MatchingEngine;
 /// </summary>
 class OrderBookLevelImpl(decimal price)
 {
-	private readonly Dictionary<long, EmulatorOrder> _ordersByTransId = [];
+	private readonly LinkedList<EmulatorOrder> _orders = [];
+	private readonly Dictionary<long, LinkedListNode<EmulatorOrder>> _nodesByTransId = [];
 
 	public decimal Price { get; } = price;
 	public decimal MarketVolume { get; set; }
 
-	public decimal TotalVolume => MarketVolume + _ordersByTransId.Values.Sum(o => o.Balance);
-	public int OrderCount => _ordersByTransId.Count;
-	public IEnumerable<EmulatorOrder> Orders => _ordersByTransId.Values;
+	public decimal TotalVolume => MarketVolume + _orders.Sum(o => o.Balance);
+	public int OrderCount => _nodesByTransId.Count;
+	public IEnumerable<EmulatorOrder> Orders => _orders;
 
 	public void AddOrder(EmulatorOrder order)
 	{
 		if (order.TransactionId == default)
 			throw new ArgumentException("TransactionId cannot be default", nameof(order));
 
-		_ordersByTransId[order.TransactionId] = order;
+		if (_nodesByTransId.TryGetValue(order.TransactionId, out var existing))
+			existing.Value = order;
+		else
+			_nodesByTransId[order.TransactionId] = _orders.AddLast(order);
 	}
 
 	public bool RemoveOrder(long transactionId, out EmulatorOrder order)
 	{
-		return _ordersByTransId.TryGetValue(transactionId, out order) && _ordersByTransId.Remove(transactionId);
+		if (_nodesByTransId.Remove(transactionId, out var node))
+		{
+			order = node.Value;
+			_orders.Remove(node);
+			return true;
+		}
+
+		order = null;
+		return false;
 	}
 
 	public bool TryGetOrder(long transactionId, out EmulatorOrder order)
 	{
-		return _ordersByTransId.TryGetValue(transactionId, out order);
+		if (_nodesByTransId.TryGetValue(transactionId, out var node))
+		{
+			order = node.Value;
+			return true;
+		}
+
+		order = null;
+		return false;
 	}
 
-	public IEnumerable<EmulatorOrder> GetAllOrders() => [.. _ordersByTransId.Values];
+	public IEnumerable<EmulatorOrder> GetAllOrders() => [.. _orders];
 
-	public bool IsEmpty => MarketVolume <= 0 && _ordersByTransId.Count == 0;
+	public bool IsEmpty => MarketVolume <= 0 && _nodesByTransId.Count == 0;
 }
 
 /// <summary>

--- a/Tests/OrderMatcherTests.cs
+++ b/Tests/OrderMatcherTests.cs
@@ -23,6 +23,35 @@ public class OrderMatcherTests : BaseTestClass
 	};
 
 	[TestMethod]
+	public void Match_AfterInteriorCancellation_PreservesFifoPriority()
+	{
+		var book = new OrderBook(CreateSecId());
+		var matcher = new OrderMatcher();
+
+		book.AddQuote(new EmulatorOrder { TransactionId = 90, Side = Sides.Buy, Price = 100, Balance = 5, Volume = 5 });
+		book.AddQuote(new EmulatorOrder { TransactionId = 2, Side = Sides.Buy, Price = 100, Balance = 3, Volume = 3 });
+		IsTrue(book.RemoveQuote(90, Sides.Buy, 100));
+		book.AddQuote(new EmulatorOrder { TransactionId = 3, Side = Sides.Buy, Price = 100, Balance = 7, Volume = 7 });
+
+		var result = matcher.Match(new EmulatorOrder
+		{
+			TransactionId = 999,
+			Side = Sides.Sell,
+			Price = 100,
+			Balance = 7,
+			Volume = 7,
+			OrderType = OrderTypes.Limit,
+			TimeInForce = TimeInForce.CancelBalance,
+		}, book, DefaultSettings);
+
+		AreEqual(0m, result.RemainingVolume);
+		var resting = book.GetOrdersAtPrice(Sides.Buy, 100).ToArray();
+		AreEqual(1, resting.Length);
+		AreEqual(3L, resting[0].TransactionId);
+		AreEqual(3m, resting[0].Balance);
+	}
+
+	[TestMethod]
 	public void Match_LimitBuy_BelowBestAsk_NoMatch()
 	{
 		var book = CreateBookWithSpread();


### PR DESCRIPTION
Fixes #681.

## What changed

- Store each price level in an explicit linked-list FIFO.
- Keep a transaction-id-to-node index so lookup and cancellation remain O(1).
- Add a regression covering an interior cancel, a later same-price arrival, and an IOC cross.

The previous dictionary enumeration could reuse a removed slot and expose the later order before an older resting order. The native regression asserts that the older maker fills first and the later maker retains the correct residual quantity.

## Verification

```
dotnet test Tests/Tests.csproj --configuration Release --no-restore \
  --filter FullyQualifiedName~Match_AfterInteriorCancellation_PreservesFifoPriority -m:1
```

Result: 1 passed, 0 failed on .NET SDK 10.0.302.
